### PR TITLE
fix: send password reset emails via resend

### DIFF
--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -439,18 +439,14 @@ export function AdminPanel() {
   const resetPassword = async (userId: string, email: string) => {
     setActionLoading(userId);
     try {
-      const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: `${window.location.origin}/auth`
-      });
-      
       console.log('🔄 Admin sending password reset email to:', email);
       const result = await emailService.sendPasswordResetEmail(email);
-      
+
       if (!result.success) {
         console.error('❌ Password reset failed:', result.error);
         throw new Error(result.error || 'Failed to send password reset email');
       }
-      
+
       console.log('✅ Password reset email sent successfully');
       alert('Password reset email sent successfully!');
     } catch (error) {


### PR DESCRIPTION
## Summary
- use custom email service for admin password resets instead of Supabase's built-in email

## Testing
- `npm run lint` *(fails: supabase is defined but never used in src/services/draftListings.ts, headers is never reassigned in src/services/email.ts, Unexpected any in src/services/footer.ts, count is assigned a value but never used in src/services/listings.ts, uploadData is assigned a value but never used in supabase/functions/move-temp-images/index.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6894c119264483299499903a4850eb18