### PR TITLE
fix: capitalize hyphenated names

### DIFF
--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -14,7 +14,11 @@ export function capitalizeName(name: string): string {
     .split(' ')
     .map(word => {
       if (word.length === 0) return word;
-      return word.charAt(0).toUpperCase() + word.slice(1);
+      // Handle hyphenated names like "mary-jane"
+      return word
+        .split('-')
+        .map(part => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+        .join('-');
     })
     .join(' ')
     .replace(/\s+/g, ' '); // Replace multiple spaces with single space


### PR DESCRIPTION
## Summary
- handle hyphenated names in `capitalizeName`

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: existing lint errors)


------
https://chatgpt.com/codex/tasks/task_e_6894c0fbb5288329b3db462297c5dfa9