### PR TITLE
fix: send password reset emails via resend

### DIFF
--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -439,18 +439,14 @@ export function AdminPanel() {
   const resetPassword = async (userId: string, email: string) => {
     setActionLoading(userId);
     try {
-      const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: `${window.location.origin}/auth`
-      });
-      
       console.log('🔄 Admin sending password reset email to:', email);
       const result = await emailService.sendPasswordResetEmail(email);
-      
+
       if (!result.success) {
         console.error('❌ Password reset failed:', result.error);
         throw new Error(result.error || 'Failed to send password reset email');
       }
-      
+
       console.log('✅ Password reset email sent successfully');
       alert('Password reset email sent successfully!');
     } catch (error) {

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -106,13 +106,13 @@ Deno.serve(async (req) => {
         });
 
         // Generate password reset link using admin client (without sending Supabase's default email)
-        const { data, error: resetError } = await supabaseAdmin.auth.admin.generatePasswordResetLink(
-          resetEmail,
-          {
+        const { data, error: resetError } = await supabaseAdmin.auth.admin.generateLink({
+          type: 'recovery',
+          email: resetEmail,
+          options: {
             redirectTo: redirectUrl,
-            sendEmail: false, // Prevent Supabase from sending its own email
-          }
-        );
+          },
+        });
 
         if (resetError) {
           console.error('❌ Error generating password reset link:', {


### PR DESCRIPTION
## Summary
- generate password reset links using Supabase's admin API
- ensure edge function sends branded password reset emails via Resend

## Testing
- `npm run lint` *(fails: supabase is defined but never used in src/services/draftListings.ts, headers is never reassigned in src/services/email.ts, Unexpected any in src/services/footer.ts, count is assigned a value but never used in src/services/listings.ts, uploadData is assigned a value but never used in supabase/functions/move-temp-images/index.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6894c119264483299499903a4850eb18