### PR TITLE
Ensure password reset emails include anon key

### DIFF
--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -19,19 +19,25 @@ export const emailService = {
   async sendEmail(emailData: EmailRequest): Promise<EmailResponse> {
     try {
       // Prepare headers
-      let headers: Record<string, string> = {
+      const headers: Record<string, string> = {
         'Content-Type': 'application/json',
       };
 
       // Skip authorization for password reset emails
       if (emailData.type !== 'password_reset') {
         const { data: { session }, error: sessionError } = await supabase.auth.getSession();
-        
+
         if (sessionError || !session) {
           throw new Error('User must be authenticated to send emails');
         }
-        
+
         headers['Authorization'] = `Bearer ${session.access_token}`;
+      } else {
+        const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+        if (!anonKey) {
+          throw new Error('Supabase anon key not configured');
+        }
+        headers['apikey'] = anonKey;
       }
 
       // Get the Supabase URL from environment variables


### PR DESCRIPTION
## Summary
- add apikey header using project anon key for password reset emails

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint src/services/email.ts`

------
https://chatgpt.com/codex/tasks/task_e_6894cba8582c832987451de8aa503027