### PR TITLE
feat: add password reset email helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 VITE_SUPABASE_URL=your_supabase_url_here
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 VITE_SUPABASE_FUNCTION_DOMAIN=pxlxdlrjmrkxyygdhvku.functions.supabase.co
+VITE_SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key_here
+VITE_RESEND_API_KEY=your_resend_api_key_here
 VITE_SITE_URL=http://localhost:5173

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,4 @@
+export const SITE_URL = import.meta.env.VITE_SITE_URL as string;
+export const RESEND_API_KEY = import.meta.env.VITE_RESEND_API_KEY as string;
+export const SUPABASE_SERVICE_ROLE_KEY = import.meta.env.VITE_SUPABASE_SERVICE_ROLE_KEY as string;
+export const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;


### PR DESCRIPTION
## Summary
- add helper to generate password reset links and send via Resend
- call helper for password reset emails
- expose RESEND and site URL config in client env

## Testing
- `npm run lint` *(fails: generateHTML is defined but never used...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894ce4acc6c8329a3dc2d5b5c5637fb