### PR TITLE
fix: import email service in EditListing

### DIFF
--- a/src/pages/EditListing.tsx
+++ b/src/pages/EditListing.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, Link } from 'react-router-dom';
 import { Upload, X, Star, ArrowLeft, Save } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import { listingsService } from '../services/listings';
+import { emailService } from '../services/email';
 import { PropertyType, ParkingType, HeatType, Listing, ListingImage, TempListingImage } from '../config/supabase';
 
 interface ListingFormData {


### PR DESCRIPTION
## Summary
- import emailService in EditListing page so updated listings send confirmation emails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 77 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6894cffc2ea4832993e902b7154cc859