### PR TITLE
secure password reset via edge function

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,4 @@
 VITE_SUPABASE_URL=your_supabase_url_here
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 VITE_SUPABASE_FUNCTION_DOMAIN=pxlxdlrjmrkxyygdhvku.functions.supabase.co
-VITE_SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key_here
-VITE_RESEND_API_KEY=your_resend_api_key_here
 VITE_SITE_URL=http://localhost:5173

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,4 +1,2 @@
 export const SITE_URL = import.meta.env.VITE_SITE_URL as string;
-export const RESEND_API_KEY = import.meta.env.VITE_RESEND_API_KEY as string;
-export const SUPABASE_SERVICE_ROLE_KEY = import.meta.env.VITE_SUPABASE_SERVICE_ROLE_KEY as string;
 export const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;

--- a/supabase/functions/send-password-reset/index.ts
+++ b/supabase/functions/send-password-reset/index.ts
@@ -1,0 +1,130 @@
+import { createClient } from 'npm:@supabase/supabase-js@2';
+import { corsHeaders } from '../_shared/cors.ts';
+
+const RESEND_API_URL = 'https://api.resend.com/emails';
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return new Response(
+      JSON.stringify({ error: 'Method not allowed' }),
+      {
+        status: 405,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      },
+    );
+  }
+
+  try {
+    const { to, subject } = await req.json();
+
+    if (!to) {
+      return new Response(
+        JSON.stringify({ error: 'Missing to field' }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+    const resendApiKey = Deno.env.get('RESEND_API_KEY');
+
+    if (!supabaseUrl || !serviceRoleKey || !resendApiKey) {
+      return new Response(
+        JSON.stringify({ error: 'Server configuration error' }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
+    const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    });
+
+    const redirectUrl = `${Deno.env.get('VITE_SITE_URL') || 'http://localhost:5173'}/auth`;
+    const email = Array.isArray(to) ? to[0] : to;
+
+    const { data, error } = await supabaseAdmin.auth.admin.generateLink({
+      type: 'recovery',
+      email,
+      options: { redirectTo: redirectUrl },
+    });
+
+    const actionLink = data?.properties?.action_link || data?.action_link;
+
+    if (error || !actionLink) {
+      return new Response(
+        JSON.stringify({ error: error?.message || 'Failed to generate reset link' }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
+    const html = `
+      <p>Click the link below to reset your password:</p>
+      <p><a href="${actionLink}">Reset Password</a></p>
+    `;
+
+    const emailPayload = {
+      from: 'HaDirot <noreply@hadirot.com>',
+      to: Array.isArray(to) ? to : [to],
+      subject: subject || 'Reset your password',
+      html,
+    };
+
+    const resendResponse = await fetch(RESEND_API_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${resendApiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(emailPayload),
+    });
+
+    const resendData = await resendResponse.json();
+
+    if (!resendResponse.ok) {
+      return new Response(
+        JSON.stringify({
+          error: resendData.error || 'Failed to send email',
+          details: resendData.details,
+        }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, id: resendData.id }),
+      {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      },
+    );
+  } catch (error) {
+    console.error('Unexpected error in send-password-reset function:', error);
+
+    return new Response(
+      JSON.stringify({ error: 'Internal server error' }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      },
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add `send-password-reset` Supabase Edge Function that creates recovery link and emails it via Resend
- route client password reset requests through new function
- drop service role key from client env files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 77 problems (57 errors, 20 warnings))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894fea902748329800947b958c2200b