### PR TITLE
Add approval check to listing approval function

### DIFF
--- a/supabase/functions/approve-listing/index.ts
+++ b/supabase/functions/approve-listing/index.ts
@@ -1,0 +1,163 @@
+import { createClient } from 'npm:@supabase/supabase-js@2';
+import { corsHeaders } from '../_shared/cors.ts';
+
+Deno.serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    // Only allow POST requests
+    if (req.method !== 'POST') {
+      return new Response(
+        JSON.stringify({ error: 'Method not allowed' }),
+        {
+          status: 405,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    // Get the authorization header
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: 'Missing authorization header' }),
+        {
+          status: 401,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    // Create Supabase admin client
+    const supabaseAdmin = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+      {
+        auth: {
+          autoRefreshToken: false,
+          persistSession: false
+        }
+      }
+    );
+
+    // Create Supabase client to verify session
+    const supabaseClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? ''
+    );
+
+    const token = authHeader.replace('Bearer ', '');
+    const { data: { user }, error: authError } = await supabaseClient.auth.getUser(token);
+
+    if (authError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid authorization' }),
+        {
+          status: 401,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    // Check if the requesting user is an admin
+    const { data: profile, error: profileError } = await supabaseClient
+      .from('profiles')
+      .select('is_admin')
+      .eq('id', user.id)
+      .single();
+
+    if (profileError || !profile?.is_admin) {
+      return new Response(
+        JSON.stringify({ error: 'Insufficient permissions' }),
+        {
+          status: 403,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    // Parse the request body to get listingId
+    const { listingId } = await req.json();
+
+    if (!listingId) {
+      return new Response(
+        JSON.stringify({ error: 'Missing listingId parameter' }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    // Update the listing only if it was previously unapproved
+    const { data, error } = await supabaseAdmin
+      .from('listings')
+      .update({ approved: true })
+      .eq('id', listingId)
+      .eq('approved', false)
+      .select('title, profiles!listings_user_id_fkey(full_name, email)')
+      .maybeSingle();
+
+    if (error) {
+      console.error('Error approving listing:', error);
+      return new Response(
+        JSON.stringify({ error: 'Failed to approve listing' }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    if (!data) {
+      return new Response(
+        JSON.stringify({ message: 'Listing not updated or already approved' }),
+        {
+          status: 200,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    // Send approval email
+    try {
+      await fetch(`${Deno.env.get('SUPABASE_URL')}/functions/v1/send-email`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')}`
+        },
+        body: JSON.stringify({
+          to: data.profiles.email,
+          subject: `Listing Approved: ${data.title}`,
+          html: `Your listing <strong>${data.title}</strong> has been approved and is now live on HaDirot!`
+        })
+      });
+    } catch (emailError) {
+      console.error('Failed to send approval email:', emailError);
+      // Continue even if email fails
+    }
+
+    return new Response(
+      JSON.stringify({ message: 'Listing approved successfully', listingId }),
+      {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      }
+    );
+
+  } catch (error) {
+    console.error('Unexpected error in approve-listing function:', error);
+    return new Response(
+      JSON.stringify({ error: 'Internal server error' }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      }
+    );
+  }
+});
+


### PR DESCRIPTION
## Summary
- add `approve-listing` Supabase function
- update listings only when transitioning from unapproved and send email

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68950a4e322483298bcb21a627be717d