### PR TITLE
feat: improve error handling in password reset function

### DIFF
--- a/supabase/functions/send-password-reset/index.ts
+++ b/supabase/functions/send-password-reset/index.ts
@@ -117,10 +117,11 @@ Deno.serve(async (req) => {
       },
     );
   } catch (error) {
-    console.error('Unexpected error in send-password-reset function:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('Unexpected error in send-password-reset function:', message);
 
     return new Response(
-      JSON.stringify({ error: 'Internal server error' }),
+      JSON.stringify({ error: 'Internal server error', message }),
       {
         status: 500,
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- improve password reset error handler to log and return error message

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 77 problems)
- `npx eslint supabase/functions/send-password-reset/index.ts && echo 'lint ok'`

------
https://chatgpt.com/codex/tasks/task_e_68957a10d6748329aff006ff71659f67