### PR TITLE
Include details in password reset error

### DIFF
--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -86,7 +86,10 @@ export function AuthForm({ onAuthSuccess }: AuthFormProps = {}) {
 
       if (!result.success) {
         console.error('❌ Password reset failed:', result.error);
-        setError(result.error || 'Failed to send password reset email');
+        const message = result.error
+          ? `${result.error}${result.details ? ` (${result.details})` : ''}`
+          : 'Failed to send password reset email';
+        setError(message);
       } else {
         console.log('✅ Password reset email sent successfully');
         setResetMessage('Password reset email sent! Check your inbox for the reset link.');


### PR DESCRIPTION
## Summary
- expand password reset failure handling to include service-provided details in error message

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 77 problems (57 errors, 20 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68957bca925c83299610a134ec23bb23