### PR TITLE
chore: add diagnostic logs to listing approval flow

### DIFF
--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -555,6 +555,7 @@ export function AdminPanel() {
   };
 
   const approveListing = async (listingId: string) => {
+    console.log('[UI] Approve clicked', { listingId });
     try {
       await listingsService.updateListing(listingId, {
         approved: true,

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -315,6 +315,7 @@ export const emailService = {
 
   // Helper function to send listing approval email
   async sendListingApprovalEmail(userEmail: string, userName: string, listingTitle: string, listingId: string): Promise<EmailResponse> {
+    console.log('[WEB] sendListingApprovalEmail called', { to: userEmail, listingId });
     const html = `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #f9f9f9;">
         <div style="background-color: #28a745; color: white; padding: 30px; text-align: center;">

--- a/supabase/functions/approve-listing/index.ts
+++ b/supabase/functions/approve-listing/index.ts
@@ -78,6 +78,7 @@ Deno.serve(async (req) => {
     }
 
     const { listingId } = await req.json();
+    console.log('[EDGE] approve-listing called', { listingId, at: new Date().toISOString() });
     if (!listingId) {
       return new Response(
         JSON.stringify({ error: 'Missing listingId parameter' }),
@@ -94,6 +95,7 @@ Deno.serve(async (req) => {
       .eq('id', listingId)
       .select('id, title, profiles!public.listings_user_id_fkey(email, full_name)')
       .single();
+    console.log('[EDGE] approve-listing updated listing to approved/active', { listingId });
 
     if (error) {
       console.error('Error approving listing:', error);


### PR DESCRIPTION
## Summary
- log calls and DB updates in approve-listing edge function
- add web-side logging for listing updates and approval email flow
- trace approval actions from AdminPanel UI

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68960e3238ec8329a3b483fbdf1af239