### PR TITLE
fix: import email service in listings

### DIFF
--- a/src/services/listings.ts
+++ b/src/services/listings.ts
@@ -1,5 +1,6 @@
 import { supabase, Listing } from '../config/supabase';
 import { capitalizeName } from '../utils/formatters';
+import { emailService } from './email';
 
 export const listingsService = {
   async getListings(filters = {}, limit?: number, userId?: string, offset = 0, applyPagination: boolean = true, is_featured_only?: boolean) {


### PR DESCRIPTION
## Summary
- import email service in listings service to use sendListingApprovalEmail

## Testing
- `npm run lint` *(fails: supabase, subject unused, unexpected any, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689657f8782c8329be086a58dc551dc8