### PR TITLE
Prevent editor focus loss and stabilize Tiptap extensions

### DIFF
--- a/src/pages/admin/StaticPageEditor.tsx
+++ b/src/pages/admin/StaticPageEditor.tsx
@@ -1,14 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Save, ArrowLeft, FileText, Bold, Italic, List, ListOrdered, Link as LinkIcon, Type, Plus, Trash2, X } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import LinkExtension from '@tiptap/extension-link';
-import Heading from '@tiptap/extension-heading';
-import BulletList from '@tiptap/extension-bullet-list';
-import OrderedList from '@tiptap/extension-ordered-list';
-import ListItem from '@tiptap/extension-list-item';
-import { generateHTML } from '@tiptap/html';
 import { staticPagesService, StaticPage } from '../../services/staticPages';
 import { footerService } from '../../services/footer';
 import { FooterSection } from '../../config/supabase';
@@ -44,27 +39,18 @@ export function StaticPageEditor() {
   });
 
   // Define extensions array for reuse
-  const extensions = [
-    StarterKit.configure({
-      heading: false, // We'll use our custom heading extension
-      bulletList: false, // We'll use our custom bullet list extension
-      orderedList: false, // We'll use our custom ordered list extension
-      listItem: false, // We'll use our custom list item extension
-      link: false, // We'll use our custom link extension
-    }),
-    Heading.configure({
-      levels: [1, 2, 3],
-    }),
-    BulletList,
-    OrderedList,
-    ListItem,
-    LinkExtension.configure({
-      openOnClick: false,
-      HTMLAttributes: {
-        class: 'text-[#4E4B43] underline hover:text-[#3a3832]',
-      },
-    }),
-  ];
+  const extensions = useMemo(
+    () => [
+      StarterKit,
+      LinkExtension.configure({
+        openOnClick: false,
+        HTMLAttributes: {
+          class: 'text-[#4E4B43] underline hover:text-[#3a3832]',
+        },
+      }),
+    ],
+    []
+  );
   const editor = useEditor({
     extensions,
     content: '',
@@ -572,6 +558,7 @@ export function StaticPageEditor() {
                       {/* Headings */}
                       <button
                         type="button"
+                        onMouseDown={(e) => e.preventDefault()}
                         onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
                         className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
                           editor.isActive('heading', { level: 1 })
@@ -583,6 +570,7 @@ export function StaticPageEditor() {
                       </button>
                       <button
                         type="button"
+                        onMouseDown={(e) => e.preventDefault()}
                         onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
                         className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
                           editor.isActive('heading', { level: 2 })
@@ -594,6 +582,7 @@ export function StaticPageEditor() {
                       </button>
                       <button
                         type="button"
+                        onMouseDown={(e) => e.preventDefault()}
                         onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
                         className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
                           editor.isActive('heading', { level: 3 })
@@ -609,6 +598,7 @@ export function StaticPageEditor() {
                       {/* Text Formatting */}
                       <button
                         type="button"
+                        onMouseDown={(e) => e.preventDefault()}
                         onClick={() => editor.chain().focus().toggleBold().run()}
                         className={`p-2 rounded transition-colors ${
                           editor.isActive('bold')
@@ -620,6 +610,7 @@ export function StaticPageEditor() {
                       </button>
                       <button
                         type="button"
+                        onMouseDown={(e) => e.preventDefault()}
                         onClick={() => editor.chain().focus().toggleItalic().run()}
                         className={`p-2 rounded transition-colors ${
                           editor.isActive('italic')
@@ -635,6 +626,7 @@ export function StaticPageEditor() {
                       {/* Lists */}
                       <button
                         type="button"
+                        onMouseDown={(e) => e.preventDefault()}
                         onClick={() => editor.chain().focus().toggleBulletList().run()}
                         className={`p-2 rounded transition-colors ${
                           editor.isActive('bulletList')
@@ -646,6 +638,7 @@ export function StaticPageEditor() {
                       </button>
                       <button
                         type="button"
+                        onMouseDown={(e) => e.preventDefault()}
                         onClick={() => editor.chain().focus().toggleOrderedList().run()}
                         className={`p-2 rounded transition-colors ${
                           editor.isActive('orderedList')
@@ -661,6 +654,7 @@ export function StaticPageEditor() {
                       {/* Links */}
                       <button
                         type="button"
+                        onMouseDown={(e) => e.preventDefault()}
                         onClick={addLink}
                         className={`p-2 rounded transition-colors ${
                           editor.isActive('link')
@@ -673,6 +667,7 @@ export function StaticPageEditor() {
                       {editor.isActive('link') && (
                         <button
                           type="button"
+                          onMouseDown={(e) => e.preventDefault()}
                           onClick={removeLink}
                           className="px-2 py-1 rounded text-xs bg-red-100 text-red-700 hover:bg-red-200 transition-colors"
                         >
@@ -685,6 +680,7 @@ export function StaticPageEditor() {
                       {/* Paragraph */}
                       <button
                         type="button"
+                        onMouseDown={(e) => e.preventDefault()}
                         onClick={() => editor.chain().focus().setParagraph().run()}
                         className={`p-2 rounded transition-colors ${
                           editor.isActive('paragraph')


### PR DESCRIPTION
## Summary
- prevent Tiptap toolbar buttons from stealing selection by adding `onMouseDown` handlers
- rely on `StarterKit` for headings and lists and memoize extensions for a stable editor instance

## Testing
- `npm run lint` *(fails: `supabase` is defined but never used and other existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689666a7cdcc83298847b319f919eef2