### PR TITLE
feat: add debug logging to Tiptap toolbar

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { staticPagesService, StaticPage } from '../services/staticPages';
 import { sanitizeHtml } from '../utils/sanitize';
+import '@/styles/static-page.css';
 
 export function About() {
   const [pageData, setPageData] = useState<StaticPage | null>(null);
@@ -54,8 +55,8 @@ export function About() {
         </p>
       </div>
 
-      <div 
-        className="prose prose-lg max-w-none text-gray-700 [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:text-[#273140] [&_h1]:mb-4 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:text-[#273140] [&_h2]:mb-3 [&_h3]:text-lg [&_h3]:font-medium [&_h3]:text-[#273140] [&_h3]:mb-2 [&_a]:text-[#273140] [&_a]:underline hover:[&_a]:text-[#1e252f] [&_ul]:list-disc [&_ul]:list-inside [&_ol]:list-decimal [&_ol]:list-inside [&_li]:mb-1"
+      <div
+        className="prose prose-lg max-w-none text-gray-700 static-page-content [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:text-[#273140] [&_h1]:mb-4 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:text-[#273140] [&_h2]:mb-3 [&_h3]:text-lg [&_h3]:font-medium [&_h3]:text-[#273140] [&_h3]:mb-2 [&_a]:text-[#273140] [&_a]:underline hover:[&_a]:text-[#1e252f]"
         dangerouslySetInnerHTML={{ __html: sanitizeHtml(pageData.content) }}
       />
     </div>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { staticPagesService, StaticPage } from '../services/staticPages';
 import { sanitizeHtml } from '../utils/sanitize';
+import '@/styles/static-page.css';
 
 export function Contact() {
   const [pageData, setPageData] = useState<StaticPage | null>(null);
@@ -53,8 +54,8 @@ export function Contact() {
         </p>
       </div>
 
-      <div 
-        className="prose prose-lg max-w-none text-gray-700 [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:text-[#273140] [&_h1]:mb-4 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:text-[#273140] [&_h2]:mb-3 [&_h3]:text-lg [&_h3]:font-medium [&_h3]:text-[#273140] [&_h3]:mb-2 [&_a]:text-[#273140] [&_a]:underline hover:[&_a]:text-[#1e252f] [&_ul]:list-disc [&_ul]:list-inside [&_ol]:list-decimal [&_ol]:list-inside [&_li]:mb-1"
+      <div
+        className="prose prose-lg max-w-none text-gray-700 static-page-content [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:text-[#273140] [&_h1]:mb-4 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:text-[#273140] [&_h2]:mb-3 [&_h3]:text-lg [&_h3]:font-medium [&_h3]:text-[#273140] [&_h3]:mb-2 [&_a]:text-[#273140] [&_a]:underline hover:[&_a]:text-[#1e252f]"
         dangerouslySetInnerHTML={{ __html: sanitizeHtml(pageData.content) }}
       />
     </div>

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { staticPagesService, StaticPage } from '../services/staticPages';
 import { sanitizeHtml } from '../utils/sanitize';
+import '@/styles/static-page.css';
 
 export function Privacy() {
   const [pageData, setPageData] = useState<StaticPage | null>(null);
@@ -53,8 +54,8 @@ export function Privacy() {
         </p>
       </div>
 
-      <div 
-        className="prose prose-lg max-w-none text-gray-700 [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:text-[#273140] [&_h1]:mb-4 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:text-[#273140] [&_h2]:mb-3 [&_h3]:text-lg [&_h3]:font-medium [&_h3]:text-[#273140] [&_h3]:mb-2 [&_a]:text-[#273140] [&_a]:underline hover:[&_a]:text-[#1e252f] [&_ul]:list-disc [&_ul]:list-inside [&_ol]:list-decimal [&_ol]:list-inside [&_li]:mb-1"
+      <div
+        className="prose prose-lg max-w-none text-gray-700 static-page-content [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:text-[#273140] [&_h1]:mb-4 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:text-[#273140] [&_h2]:mb-3 [&_h3]:text-lg [&_h3]:font-medium [&_h3]:text-[#273140] [&_h3]:mb-2 [&_a]:text-[#273140] [&_a]:underline hover:[&_a]:text-[#1e252f]"
         dangerouslySetInnerHTML={{ __html: sanitizeHtml(pageData.content) }}
       />
     </div>

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { staticPagesService, StaticPage } from '../services/staticPages';
 import { sanitizeHtml } from '../utils/sanitize';
+import '@/styles/static-page.css';
 
 export function Terms() {
   const [pageData, setPageData] = useState<StaticPage | null>(null);
@@ -53,8 +54,8 @@ export function Terms() {
         </p>
       </div>
 
-      <div 
-        className="prose prose-lg max-w-none text-gray-700 [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:text-[#273140] [&_h1]:mb-4 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:text-[#273140] [&_h2]:mb-3 [&_h3]:text-lg [&_h3]:font-medium [&_h3]:text-[#273140] [&_h3]:mb-2 [&_a]:text-[#273140] [&_a]:underline hover:[&_a]:text-[#1e252f] [&_ul]:list-disc [&_ul]:list-inside [&_ol]:list-decimal [&_ol]:list-inside [&_li]:mb-1"
+      <div
+        className="prose prose-lg max-w-none text-gray-700 static-page-content [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:text-[#273140] [&_h1]:mb-4 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:text-[#273140] [&_h2]:mb-3 [&_h3]:text-lg [&_h3]:font-medium [&_h3]:text-[#273140] [&_h3]:mb-2 [&_a]:text-[#273140] [&_a]:underline hover:[&_a]:text-[#1e252f]"
         dangerouslySetInnerHTML={{ __html: sanitizeHtml(pageData.content) }}
       />
     </div>

--- a/src/pages/admin/StaticPageEditor.tsx
+++ b/src/pages/admin/StaticPageEditor.tsx
@@ -21,6 +21,7 @@ import { staticPagesService, StaticPage } from "../../services/staticPages";
 import { footerService } from "../../services/footer";
 import { FooterSection } from "../../config/supabase";
 import { useAuth } from "../../hooks/useAuth";
+import "@/styles/editor.css";
 
 export function StaticPageEditor() {
   const { user, profile } = useAuth();
@@ -941,11 +942,8 @@ export function StaticPageEditor() {
                   )}
 
                   {/* Rich Text Editor Content */}
-                  <div className="border border-gray-300 rounded-b-md min-h-[400px] max-h-[600px] overflow-y-auto">
-                    <EditorContent
-                      editor={editor}
-                      className="prose prose-sm max-w-none p-4 focus:outline-none [&_.ProseMirror]:outline-none [&_.ProseMirror]:min-h-[350px] [&_.ProseMirror]:cursor-text"
-                    />
+                  <div className="editor-shell border border-gray-300 rounded-b-md min-h-[400px] max-h-[600px] overflow-y-auto p-4">
+                    <EditorContent editor={editor} />
                   </div>
 
                   <p className="text-xs text-gray-500 mt-1">

--- a/src/pages/admin/StaticPageEditor.tsx
+++ b/src/pages/admin/StaticPageEditor.tsx
@@ -675,13 +675,27 @@ export function StaticPageEditor() {
                       <button
                         type="button"
                         onMouseDown={(e) => e.preventDefault()}
-                        onClick={() =>
-                          editor
+                        onClick={() => {
+                          if (!editor) return;
+                          const can = editor
+                            .can()
                             .chain()
                             .focus()
                             .toggleHeading({ level: 1 })
-                            .run()
-                        }
+                            .run();
+                          console.log("[TT] can-run?", can, {
+                            selection: {
+                              from: editor.state.selection.from,
+                              to: editor.state.selection.to,
+                            },
+                            isHeading2: editor.isActive("heading", { level: 2 }),
+                            isBullet: editor.isActive("bulletList"),
+                            isOrdered: editor.isActive("orderedList"),
+                            activeNode: editor.getAttributes("heading"),
+                          });
+                          editor.chain().focus().toggleHeading({ level: 1 }).run();
+                          console.log("[TT] doc after command", editor.getJSON());
+                        }}
                         className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
                           editor.isActive("heading", { level: 1 })
                             ? "bg-[#273140] text-white"
@@ -693,13 +707,27 @@ export function StaticPageEditor() {
                       <button
                         type="button"
                         onMouseDown={(e) => e.preventDefault()}
-                        onClick={() =>
-                          editor
+                        onClick={() => {
+                          if (!editor) return;
+                          const can = editor
+                            .can()
                             .chain()
                             .focus()
                             .toggleHeading({ level: 2 })
-                            .run()
-                        }
+                            .run();
+                          console.log("[TT] can-run?", can, {
+                            selection: {
+                              from: editor.state.selection.from,
+                              to: editor.state.selection.to,
+                            },
+                            isHeading2: editor.isActive("heading", { level: 2 }),
+                            isBullet: editor.isActive("bulletList"),
+                            isOrdered: editor.isActive("orderedList"),
+                            activeNode: editor.getAttributes("heading"),
+                          });
+                          editor.chain().focus().toggleHeading({ level: 2 }).run();
+                          console.log("[TT] doc after command", editor.getJSON());
+                        }}
                         className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
                           editor.isActive("heading", { level: 2 })
                             ? "bg-[#273140] text-white"
@@ -711,13 +739,27 @@ export function StaticPageEditor() {
                       <button
                         type="button"
                         onMouseDown={(e) => e.preventDefault()}
-                        onClick={() =>
-                          editor
+                        onClick={() => {
+                          if (!editor) return;
+                          const can = editor
+                            .can()
                             .chain()
                             .focus()
                             .toggleHeading({ level: 3 })
-                            .run()
-                        }
+                            .run();
+                          console.log("[TT] can-run?", can, {
+                            selection: {
+                              from: editor.state.selection.from,
+                              to: editor.state.selection.to,
+                            },
+                            isHeading2: editor.isActive("heading", { level: 2 }),
+                            isBullet: editor.isActive("bulletList"),
+                            isOrdered: editor.isActive("orderedList"),
+                            activeNode: editor.getAttributes("heading"),
+                          });
+                          editor.chain().focus().toggleHeading({ level: 3 }).run();
+                          console.log("[TT] doc after command", editor.getJSON());
+                        }}
                         className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
                           editor.isActive("heading", { level: 3 })
                             ? "bg-[#273140] text-white"
@@ -765,9 +807,27 @@ export function StaticPageEditor() {
                       <button
                         type="button"
                         onMouseDown={(e) => e.preventDefault()}
-                        onClick={() =>
-                          editor.chain().focus().toggleBulletList().run()
-                        }
+                        onClick={() => {
+                          if (!editor) return;
+                          const can = editor
+                            .can()
+                            .chain()
+                            .focus()
+                            .toggleBulletList()
+                            .run();
+                          console.log("[TT] can-run?", can, {
+                            selection: {
+                              from: editor.state.selection.from,
+                              to: editor.state.selection.to,
+                            },
+                            isHeading2: editor.isActive("heading", { level: 2 }),
+                            isBullet: editor.isActive("bulletList"),
+                            isOrdered: editor.isActive("orderedList"),
+                            activeNode: editor.getAttributes("heading"),
+                          });
+                          editor.chain().focus().toggleBulletList().run();
+                          console.log("[TT] doc after command", editor.getJSON());
+                        }}
                         className={`p-2 rounded transition-colors ${
                           editor.isActive("bulletList")
                             ? "bg-[#273140] text-white"
@@ -779,9 +839,27 @@ export function StaticPageEditor() {
                       <button
                         type="button"
                         onMouseDown={(e) => e.preventDefault()}
-                        onClick={() =>
-                          editor.chain().focus().toggleOrderedList().run()
-                        }
+                        onClick={() => {
+                          if (!editor) return;
+                          const can = editor
+                            .can()
+                            .chain()
+                            .focus()
+                            .toggleOrderedList()
+                            .run();
+                          console.log("[TT] can-run?", can, {
+                            selection: {
+                              from: editor.state.selection.from,
+                              to: editor.state.selection.to,
+                            },
+                            isHeading2: editor.isActive("heading", { level: 2 }),
+                            isBullet: editor.isActive("bulletList"),
+                            isOrdered: editor.isActive("orderedList"),
+                            activeNode: editor.getAttributes("heading"),
+                          });
+                          editor.chain().focus().toggleOrderedList().run();
+                          console.log("[TT] doc after command", editor.getJSON());
+                        }}
                         className={`p-2 rounded transition-colors ${
                           editor.isActive("orderedList")
                             ? "bg-[#273140] text-white"
@@ -833,6 +911,31 @@ export function StaticPageEditor() {
                         }`}
                       >
                         <Type className="w-4 h-4" />
+                      </button>
+
+                      <div className="w-px h-6 bg-gray-300 mx-1"></div>
+
+                      <button
+                        type="button"
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={() => {
+                          if (!editor) return;
+                          console.log("[TT] debug snapshot", {
+                            selection: {
+                              from: editor.state.selection.from,
+                              to: editor.state.selection.to,
+                            },
+                            isH1: editor.isActive("heading", { level: 1 }),
+                            isH2: editor.isActive("heading", { level: 2 }),
+                            isH3: editor.isActive("heading", { level: 3 }),
+                            isBullet: editor.isActive("bulletList"),
+                            isOrdered: editor.isActive("orderedList"),
+                            json: editor.getJSON(),
+                          });
+                        }}
+                        className="px-3 py-1 rounded text-xs font-medium bg-white text-gray-700 hover:bg-gray-100"
+                      >
+                        Debug
                       </button>
                     </div>
                   )}

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -1,0 +1,17 @@
+.editor-shell .ProseMirror {
+  min-height: 16rem;
+  outline: none;
+  /* spacing */
+  line-height: 1.6;
+}
+.editor-shell .ProseMirror p { margin: 0.5rem 0; }
+.editor-shell .ProseMirror h1 { font-size: 1.875rem; line-height: 2.25rem; font-weight: 700; margin: 1rem 0 0.5rem; }
+.editor-shell .ProseMirror h2 { font-size: 1.5rem; line-height: 2rem; font-weight: 700; margin: 0.875rem 0 0.5rem; }
+.editor-shell .ProseMirror h3 { font-size: 1.25rem; line-height: 1.75rem; font-weight: 600; margin: 0.75rem 0 0.5rem; }
+/* lists */
+.editor-shell .ProseMirror ul { list-style: disc; padding-left: 1.5rem; margin: 0.5rem 0; }
+.editor-shell .ProseMirror ol { list-style: decimal; padding-left: 1.5rem; margin: 0.5rem 0; }
+.editor-shell .ProseMirror li { margin: 0.25rem 0; }
+/* make sure nested lists display correctly */
+.editor-shell .ProseMirror li > ul,
+.editor-shell .ProseMirror li > ol { margin: 0.25rem 0 0.25rem 1rem; }

--- a/src/styles/static-page.css
+++ b/src/styles/static-page.css
@@ -1,0 +1,36 @@
+/* Base text rhythm */
+.prose.static-page-content {
+  line-height: 1.7;
+}
+.prose.static-page-content p {
+  margin: 0.75rem 0;
+}
+
+/* Lists: make bullets align with text baseline and indent correctly */
+.prose.static-page-content ul,
+.prose.static-page-content ol {
+  list-style-position: outside;
+  padding-left: 1.5rem;  /* indent */
+  margin: 0.75rem 0;
+}
+.prose.static-page-content li {
+  display: list-item;         /* ensure list formatting */
+  vertical-align: baseline;   /* align marker with text */
+  margin: 0.25rem 0;
+  line-height: 1.7;           /* match container line-height */
+}
+/* Tiptap outputs <li><p>…</p></li>; remove extra top/bottom gap from inner p */
+.prose.static-page-content li > p {
+  margin: 0;                  /* prevents bullet floating above text */
+}
+
+/* Nested lists */
+.prose.static-page-content li > ul,
+.prose.static-page-content li > ol {
+  margin: 0.25rem 0 0.25rem 1rem;
+}
+
+/* Optional: heading rhythm to match editor */
+.prose.static-page-content h1 { font-size: 1.875rem; line-height: 2.25rem; font-weight: 700; margin: 1rem 0 0.5rem; }
+.prose.static-page-content h2 { font-size: 1.5rem;   line-height: 2rem;    font-weight: 700; margin: 0.875rem 0 0.5rem; }
+.prose.static-page-content h3 { font-size: 1.25rem;  line-height: 1.75rem; font-weight: 600; margin: 0.75rem 0 0.5rem; }

--- a/src/styles/static-page.css
+++ b/src/styles/static-page.css
@@ -1,36 +1,50 @@
 /* Base text rhythm */
-.prose.static-page-content {
+.static-page-content {
   line-height: 1.7;
 }
-.prose.static-page-content p {
+.static-page-content p {
   margin: 0.75rem 0;
 }
 
 /* Lists: make bullets align with text baseline and indent correctly */
-.prose.static-page-content ul,
-.prose.static-page-content ol {
+.static-page-content ul,
+.static-page-content ol {
   list-style-position: outside;
   padding-left: 1.5rem;  /* indent */
   margin: 0.75rem 0;
-}
-.prose.static-page-content li {
-  display: list-item;         /* ensure list formatting */
-  vertical-align: baseline;   /* align marker with text */
-  margin: 0.25rem 0;
-  line-height: 1.7;           /* match container line-height */
-}
-/* Tiptap outputs <li><p>…</p></li>; remove extra top/bottom gap from inner p */
-.prose.static-page-content li > p {
-  margin: 0;                  /* prevents bullet floating above text */
+  list-style: revert !important;      /* re-enable UA defaults if something killed it */
 }
 
+.static-page-content ul { list-style-type: disc !important; }
+.static-page-content ol { list-style-type: decimal !important; }
+
+.static-page-content li {
+  display: list-item;                 /* ensure list semantics even if reset changed it */
+  vertical-align: baseline;
+  line-height: 1.7;
+  margin: 0.25rem 0;
+}
+/* Tiptap outputs <li><p>…</p></li>; remove extra top/bottom gap from inner p */
+.static-page-content li > p { margin: 0; }
+
+/* If any global reset set marker to empty, undo it */
+.static-page-content li::marker { content: initial !important; }
+
 /* Nested lists */
-.prose.static-page-content li > ul,
-.prose.static-page-content li > ol {
+.static-page-content li > ul,
+.static-page-content li > ol {
   margin: 0.25rem 0 0.25rem 1rem;
 }
 
 /* Optional: heading rhythm to match editor */
-.prose.static-page-content h1 { font-size: 1.875rem; line-height: 2.25rem; font-weight: 700; margin: 1rem 0 0.5rem; }
-.prose.static-page-content h2 { font-size: 1.5rem;   line-height: 2rem;    font-weight: 700; margin: 0.875rem 0 0.5rem; }
-.prose.static-page-content h3 { font-size: 1.25rem;  line-height: 1.75rem; font-weight: 600; margin: 0.75rem 0 0.5rem; }
+.static-page-content h1 { font-size: 1.875rem; line-height: 2.25rem; font-weight: 700; margin: 1rem 0 0.5rem; }
+.static-page-content h2 { font-size: 1.5rem;   line-height: 2rem;    font-weight: 700; margin: 0.875rem 0 0.5rem; }
+.static-page-content h3 { font-size: 1.25rem;  line-height: 1.75rem; font-weight: 600; margin: 0.75rem 0 0.5rem; }
+
+/* If Tailwind Typography (.prose) is used on the same wrapper, out-spec it */
+.prose.static-page-content ul,
+.prose.static-page-content ol {
+  list-style: revert !important;
+  list-style-position: outside;
+  padding-left: 1.5rem;
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -18,7 +18,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -16,7 +16,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { fileURLToPath, URL } from 'node:url';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
## Summary
- add diagnostic logging to heading buttons
- log node state for list commands
- add temporary debug snapshot button

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a0e3a7f848329aab237a146b1deab