### PR TITLE
Fix listing form neighborhood input, image features, and compression

### DIFF
--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -1,0 +1,46 @@
+export interface CompressOptions {
+  quality?: number;
+  maxWidth?: number;
+}
+
+export function compressImage(
+  file: File,
+  opts: CompressOptions = {},
+): Promise<Blob> {
+  const { quality = 0.8, maxWidth = 1920 } = opts;
+
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = (err) => reject(err);
+    reader.onload = () => {
+      const img = new Image();
+      img.onerror = (err) => reject(err);
+      img.onload = () => {
+        let { width, height } = img;
+        if (width > maxWidth) {
+          height = (height * maxWidth) / width;
+          width = maxWidth;
+        }
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+          reject(new Error("Canvas context not available"));
+          return;
+        }
+        ctx.drawImage(img, 0, 0, width, height);
+        canvas.toBlob(
+          (blob) => {
+            if (blob) resolve(blob);
+            else reject(new Error("Image compression failed"));
+          },
+          "image/jpeg",
+          quality,
+        );
+      };
+      img.src = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  });
+}


### PR DESCRIPTION
## Summary
- support custom neighborhood entry without resetting select
- ensure only one image is featured and compress uploads beyond 8MB
- add reusable client-side image compression utility

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b55a02eb48329a02c774fe414aa3b