### PR TITLE
Stack fee and parking filters; fetch active neighborhoods

### DIFF
--- a/src/components/listings/ListingCard.tsx
+++ b/src/components/listings/ListingCard.tsx
@@ -159,7 +159,7 @@ export function ListingCard({
         <div className="mt-2 pt-2 border-t border-gray-100 flex items-center justify-between">
           <span className="text-xs text-gray-600">by {getPosterLabel()}</span>
           {listing.is_featured && showFeaturedBadge && (
-            <span className="inline-flex items-center rounded px-2 py-0.5 text-xs font-medium bg-brand-600 text-white">
+            <span className="inline-flex items-center bg-accent-500 text-white text-xs px-2 py-0.5 rounded">
               Featured
             </span>
           )}

--- a/src/components/listings/ListingFilters.tsx
+++ b/src/components/listings/ListingFilters.tsx
@@ -10,7 +10,7 @@ interface FilterState {
   min_price?: number;
   max_price?: number;
   parking_included?: boolean;
-  no_fee_only?: boolean;
+  no_broker_fee_only?: boolean;
   neighborhoods?: string[];
 }
 

--- a/src/components/listings/ListingFilters.tsx
+++ b/src/components/listings/ListingFilters.tsx
@@ -85,7 +85,7 @@ export function ListingFilters({
       </div>
 
       <div
-        className={`grid gap-4 auto-rows-fr ${
+        className={`grid gap-4 ${
           isMobile
             ? "grid-cols-1"
             : "grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-7"
@@ -321,8 +321,8 @@ export function ListingFilters({
         </div>
 
         {/* Parking Included & No Fee */}
-        <div className="flex flex-col justify-between h-full min-h-[88px]">
-          <div className="flex items-center">
+        <div className="flex flex-col space-y-2">
+          <label className="flex items-start gap-2">
             <input
               type="checkbox"
               id="parking_included"
@@ -332,15 +332,12 @@ export function ListingFilters({
               }
               className="h-4 w-4 text-[#273140] focus:ring-[#273140] border-gray-300 rounded"
             />
-            <label
-              htmlFor="parking_included"
-              className="ml-2 text-sm font-medium text-gray-700"
-            >
+            <span className="text-sm font-medium text-gray-700">
               Parking Included
-            </label>
-          </div>
+            </span>
+          </label>
 
-          <div className="flex items-center">
+          <label className="flex items-start gap-2">
             <input
               type="checkbox"
               id="no_fee_only"
@@ -350,13 +347,10 @@ export function ListingFilters({
               }
               className="h-4 w-4 text-[#273140] focus:ring-[#273140] border-gray-300 rounded"
             />
-            <label
-              htmlFor="no_fee_only"
-              className="ml-2 text-sm font-medium text-gray-700"
-            >
+            <span className="text-sm font-medium text-gray-700">
               No Fee only
-            </label>
-          </div>
+            </span>
+          </label>
         </div>
       </div>
 

--- a/src/components/listings/ListingFilters.tsx
+++ b/src/components/listings/ListingFilters.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Filter } from "lucide-react";
+import { listingsService } from "../../services/listings";
 
 interface FilterState {
   bedrooms?: number;
@@ -17,7 +18,7 @@ interface ListingFiltersProps {
   filters: FilterState;
   onFiltersChange: (filters: FilterState) => void;
   agencies: string[];
-  allNeighborhoods: string[];
+  allNeighborhoods?: string[];
   isMobile?: boolean;
 }
 
@@ -25,11 +26,22 @@ export function ListingFilters({
   filters,
   onFiltersChange,
   agencies,
-  allNeighborhoods,
+  allNeighborhoods = [],
   isMobile = false,
 }: ListingFiltersProps) {
   const [showNeighborhoodDropdown, setShowNeighborhoodDropdown] =
     React.useState(false);
+  const [neighborhoodOptions, setNeighborhoodOptions] = React.useState<string[]>(
+    allNeighborhoods,
+  );
+
+  React.useEffect(() => {
+    const loadNeighborhoods = async () => {
+      const neighborhoods = await listingsService.getActiveNeighborhoods();
+      setNeighborhoodOptions(neighborhoods);
+    };
+    loadNeighborhoods();
+  }, []);
 
   // Close dropdown when clicking outside
   React.useEffect(() => {
@@ -73,7 +85,11 @@ export function ListingFilters({
       </div>
 
       <div
-        className={`grid gap-4 ${isMobile ? "grid-cols-1" : "grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-7"}`}
+        className={`grid gap-4 auto-rows-fr ${
+          isMobile
+            ? "grid-cols-1"
+            : "grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-7"
+        }`}
       >
         {/* Bedrooms */}
         <div>
@@ -163,79 +179,88 @@ export function ListingFilters({
           <label className="block text-sm font-medium text-gray-700 mb-1">
             Neighborhoods
           </label>
-          <div className="relative">
-            <div
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus-within:ring-[#273140] focus-within:border-[#273140] h-10 cursor-pointer bg-white flex items-center justify-between"
-              onClick={() =>
-                setShowNeighborhoodDropdown(!showNeighborhoodDropdown)
-              }
-            >
-              <span className="text-sm text-gray-700 truncate">
-                {filters.neighborhoods && filters.neighborhoods.length > 0
-                  ? `${filters.neighborhoods.length} selected`
-                  : "Select neighborhoods..."}
-              </span>
-              <svg
-                className="w-4 h-4 text-gray-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
+          {neighborhoodOptions.length > 0 ? (
+            <div className="relative">
+              <div
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus-within:ring-[#273140] focus-within:border-[#273140] h-10 cursor-pointer bg-white flex items-center justify-between"
+                onClick={() =>
+                  setShowNeighborhoodDropdown(!showNeighborhoodDropdown)
+                }
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M19 9l-7 7-7-7"
-                />
-              </svg>
-            </div>
-
-            {showNeighborhoodDropdown && (
-              <div className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-y-auto">
-                {allNeighborhoods.map((neighborhood) => (
-                  <div
-                    key={neighborhood}
-                    className="px-3 py-2 hover:bg-gray-50 cursor-pointer flex items-center"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      const currentNeighborhoods = filters.neighborhoods || [];
-                      const isSelected =
-                        currentNeighborhoods.includes(neighborhood);
-
-                      let newNeighborhoods;
-                      if (isSelected) {
-                        newNeighborhoods = currentNeighborhoods.filter(
-                          (n) => n !== neighborhood,
-                        );
-                      } else {
-                        newNeighborhoods = [
-                          ...currentNeighborhoods,
-                          neighborhood,
-                        ];
-                      }
-
-                      handleFilterChange(
-                        "neighborhoods",
-                        newNeighborhoods.length > 0
-                          ? newNeighborhoods
-                          : undefined,
-                      );
-                    }}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={
-                        filters.neighborhoods?.includes(neighborhood) || false
-                      }
-                      onChange={() => {}} // Handled by parent div onClick
-                      className="mr-2 h-4 w-4 text-[#273140] focus:ring-[#273140] border-gray-300 rounded"
-                    />
-                    <span className="text-sm">{neighborhood}</span>
-                  </div>
-                ))}
+                <span className="text-sm text-gray-700 truncate">
+                  {filters.neighborhoods && filters.neighborhoods.length > 0
+                    ? `${filters.neighborhoods.length} selected`
+                    : "Select neighborhoods..."}
+                </span>
+                <svg
+                  className="w-4 h-4 text-gray-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
               </div>
-            )}
-          </div>
+
+              {showNeighborhoodDropdown && (
+                <div className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-y-auto">
+                  {neighborhoodOptions.map((neighborhood) => (
+                    <div
+                      key={neighborhood}
+                      className="px-3 py-2 hover:bg-gray-50 cursor-pointer flex items-center"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        const currentNeighborhoods = filters.neighborhoods || [];
+                        const isSelected =
+                          currentNeighborhoods.includes(neighborhood);
+
+                        let newNeighborhoods;
+                        if (isSelected) {
+                          newNeighborhoods = currentNeighborhoods.filter(
+                            (n) => n !== neighborhood,
+                          );
+                        } else {
+                          newNeighborhoods = [
+                            ...currentNeighborhoods,
+                            neighborhood,
+                          ];
+                        }
+
+                        handleFilterChange(
+                          "neighborhoods",
+                          newNeighborhoods.length > 0
+                            ? newNeighborhoods
+                            : undefined,
+                        );
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={
+                          filters.neighborhoods?.includes(neighborhood) || false
+                        }
+                        onChange={() => {}} // Handled by parent div onClick
+                        className="mr-2 h-4 w-4 text-[#273140] focus:ring-[#273140] border-gray-300 rounded"
+                      />
+                      <span className="text-sm">{neighborhood}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : (
+            <select
+              disabled
+              className="w-full px-3 py-2 border border-gray-300 rounded-md bg-gray-50 text-gray-500"
+            >
+              <option>No neighborhoods available</option>
+            </select>
+          )}
         </div>
 
         {/* Property Type */}
@@ -295,42 +320,43 @@ export function ListingFilters({
           />
         </div>
 
-        {/* Parking Included */}
-        <div className="flex items-center pt-6">
-          <input
-            type="checkbox"
-            id="parking_included"
-            checked={filters.parking_included || false}
-            onChange={(e) =>
-              handleFilterChange("parking_included", e.target.checked)
-            }
-            className="h-4 w-4 text-[#273140] focus:ring-[#273140] border-gray-300 rounded"
-          />
-          <label
-            htmlFor="parking_included"
-            className="ml-2 text-sm font-medium text-gray-700"
-          >
-            Parking Included
-          </label>
-        </div>
+        {/* Parking Included & No Fee */}
+        <div className="flex flex-col justify-between h-full min-h-[88px]">
+          <div className="flex items-center">
+            <input
+              type="checkbox"
+              id="parking_included"
+              checked={filters.parking_included || false}
+              onChange={(e) =>
+                handleFilterChange("parking_included", e.target.checked)
+              }
+              className="h-4 w-4 text-[#273140] focus:ring-[#273140] border-gray-300 rounded"
+            />
+            <label
+              htmlFor="parking_included"
+              className="ml-2 text-sm font-medium text-gray-700"
+            >
+              Parking Included
+            </label>
+          </div>
 
-        {/* No Fee only */}
-        <div className="flex items-center pt-6">
-          <input
-            type="checkbox"
-            id="no_fee_only"
-            checked={filters.no_fee_only || false}
-            onChange={(e) =>
-              handleFilterChange("no_fee_only", e.target.checked)
-            }
-            className="h-4 w-4 text-[#273140] focus:ring-[#273140] border-gray-300 rounded"
-          />
-          <label
-            htmlFor="no_fee_only"
-            className="ml-2 text-sm font-medium text-gray-700"
-          >
-            No Fee only
-          </label>
+          <div className="flex items-center">
+            <input
+              type="checkbox"
+              id="no_fee_only"
+              checked={filters.no_fee_only || false}
+              onChange={(e) =>
+                handleFilterChange("no_fee_only", e.target.checked)
+              }
+              className="h-4 w-4 text-[#273140] focus:ring-[#273140] border-gray-300 rounded"
+            />
+            <label
+              htmlFor="no_fee_only"
+              className="ml-2 text-sm font-medium text-gray-700"
+            >
+              No Fee only
+            </label>
+          </div>
         </div>
       </div>
 

--- a/src/components/listings/ListingFilters.tsx
+++ b/src/components/listings/ListingFilters.tsx
@@ -10,7 +10,7 @@ interface FilterState {
   min_price?: number;
   max_price?: number;
   parking_included?: boolean;
-  no_broker_fee_only?: boolean;
+  no_fee_only?: boolean;
   neighborhoods?: string[];
 }
 

--- a/src/components/listings/ListingFilters.tsx
+++ b/src/components/listings/ListingFilters.tsx
@@ -321,7 +321,7 @@ export function ListingFilters({
         </div>
 
         {/* Parking Included & No Fee */}
-        <div className="flex flex-col space-y-2">
+        <div className="flex flex-col space-y-2 justify-end">
           <label className="flex items-start gap-2">
             <input
               type="checkbox"

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -420,8 +420,8 @@ export function ListingDetail() {
 
               <div className="flex flex-wrap gap-2">
                 {listing.is_featured && (
-                  <span className="bg-accent-500 text-white px-3 py-1 rounded-full text-sm font-medium flex items-center">
-                    <Star className="w-4 h-4 mr-1" />
+                  <span className="inline-flex items-center bg-accent-500 text-white text-xs px-2 py-0.5 rounded">
+                    <Star className="w-3 h-3 mr-1" />
                     Featured
                   </span>
                 )}

--- a/src/services/listings.ts
+++ b/src/services/listings.ts
@@ -744,23 +744,35 @@ export const listingsService = {
    return data;
  },
 
-async getUniqueNeighborhoods(): Promise<string[]> {
+async getActiveNeighborhoods(): Promise<string[]> {
   const { data, error } = await supabase
     .from('listings')
     .select('neighborhood')
     .eq('is_active', true)
-    .eq('approved', true)
-    .not('neighborhood', 'is', null)
-    .neq('neighborhood', '');
+    .eq('approved', true);
 
   if (error) {
     console.error('Error fetching neighborhoods:', error);
     return [];
   }
 
-  // Extract unique neighborhoods and sort them
-  const neighborhoods = [...new Set(data.map(item => item.neighborhood))];
-  return neighborhoods.sort();
+  const neighborhoods = [...new Set(
+    (data || [])
+      .map((item) => (item.neighborhood || '').trim())
+      .filter(
+        (n) =>
+          n &&
+          n !== '-' &&
+          n.replace(/\s/g, '') !== '' &&
+          n.length > 0,
+      ),
+  )].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+
+  return neighborhoods;
+},
+
+async getUniqueNeighborhoods(): Promise<string[]> {
+  return this.getActiveNeighborhoods();
 },
 
   async getGlobalFeaturedCount(): Promise<number> {


### PR DESCRIPTION
## Summary
- Stack parking and no-fee checkboxes into single grid column with consistent height
- Load neighborhood options from active approved listings only

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c904c2e788329a45ef6e8b50a206a