### PR TITLE
Rename no fee filter label to no broker fee

### DIFF
--- a/src/components/listings/ListingFilters.tsx
+++ b/src/components/listings/ListingFilters.tsx
@@ -348,7 +348,7 @@ export function ListingFilters({
               className="h-4 w-4 text-[#273140] focus:ring-[#273140] border-gray-300 rounded"
             />
             <span className="text-sm font-medium text-gray-700">
-              No Fee only
+              No Broker Fee only
             </span>
           </label>
         </div>


### PR DESCRIPTION
## Summary
- rename the "No Fee only" filter label to "No Broker Fee only"

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c9a09047483299a3e79bba9d68dcd