### PR TITLE
feat: add responsive image carousel

### DIFF
--- a/src/components/media/ImageCarousel.tsx
+++ b/src/components/media/ImageCarousel.tsx
@@ -1,0 +1,216 @@
+import React, { useState, useRef, useEffect } from "react";
+
+export type CarouselImage = { url: string; alt?: string | null };
+
+interface ImageCarouselProps {
+  images: CarouselImage[];
+  initialIndex?: number;
+  fit?: "cover" | "contain";
+  heightClass?: string;
+  showThumbnails?: boolean;
+  className?: string;
+}
+
+function cn(...classes: (string | undefined | null | false)[]) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export function ImageCarousel({
+  images,
+  initialIndex = 0,
+  fit = "contain",
+  heightClass = "h-[48vh] lg:h-[56vh]",
+  showThumbnails = true,
+  className,
+}: ImageCarouselProps) {
+  const [current, setCurrent] = useState(initialIndex);
+  const startX = useRef<number | null>(null);
+  const deltaX = useRef(0);
+
+  useEffect(() => {
+    setCurrent(initialIndex);
+  }, [initialIndex]);
+
+  const clamp = (i: number) => Math.max(0, Math.min(images.length - 1, i));
+  const prev = () => setCurrent((i) => clamp(i - 1));
+  const next = () => setCurrent((i) => clamp(i + 1));
+  const goTo = (i: number) => setCurrent(clamp(i));
+
+  const handleKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      prev();
+    }
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      next();
+    }
+  };
+
+  const onTouchStart = (e: React.TouchEvent) => {
+    startX.current = e.touches[0].clientX;
+    deltaX.current = 0;
+  };
+
+  const onTouchMove = (e: React.TouchEvent) => {
+    if (startX.current !== null) {
+      deltaX.current = e.touches[0].clientX - startX.current;
+    }
+  };
+
+  const onTouchEnd = () => {
+    if (startX.current !== null) {
+      if (Math.abs(deltaX.current) > 40) {
+        if (deltaX.current > 0) prev();
+        else next();
+      }
+    }
+    startX.current = null;
+    deltaX.current = 0;
+  };
+
+  if (!images || images.length === 0) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-center rounded-xl bg-gray-100 text-gray-500",
+          heightClass,
+          className,
+        )}
+        role="region"
+        aria-label="Listing images"
+      >
+        <svg
+          className="h-10 w-10"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path d="M3 10.5L12 3l9 7.5v9A1.5 1.5 0 0 1 19.5 21h-15A1.5 1.5 0 0 1 3 19.5v-9z" />
+          <path d="M9 21V12h6v9" />
+        </svg>
+        <span className="ml-2">No image</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "grid grid-rows-[auto_auto] lg:grid-rows-1 lg:grid-cols-[1fr_120px] gap-3",
+        className,
+      )}
+    >
+      <div
+        role="region"
+        aria-label="Listing images"
+        tabIndex={0}
+        className={cn(
+          "relative w-full overflow-hidden rounded-xl bg-neutral-900",
+          heightClass,
+        )}
+        onKeyDown={handleKey}
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+      >
+        <div
+          className="flex h-full transition-transform duration-300"
+          style={{ transform: `translateX(-${current * 100}%)` }}
+        >
+          {images.map((img, i) => (
+            <div key={i} className="relative h-full w-full shrink-0">
+              <img
+                src={img.url}
+                alt={img.alt ?? "Listing image"}
+                loading="lazy"
+                decoding="async"
+                className={cn(
+                  "absolute inset-0 h-full w-full bg-neutral-900",
+                  fit === "contain" ? "object-contain" : "object-cover",
+                )}
+                onError={(e) => (e.currentTarget.style.opacity = "0")}
+              />
+            </div>
+          ))}
+        </div>
+
+        {images.length > 1 && (
+          <>
+            <button
+              onClick={prev}
+              className="absolute left-2 top-1/2 -translate-y-1/2 hidden md:flex h-9 w-9 items-center justify-center rounded-full shadow bg-black/50 text-white hover:bg-black/60 focus:outline-none"
+              aria-label="Previous image"
+              title="Previous image"
+            >
+              <svg
+                className="h-5 w-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M15 18l-6-6 6-6" />
+              </svg>
+            </button>
+            <button
+              onClick={next}
+              className="absolute right-2 top-1/2 -translate-y-1/2 hidden md:flex h-9 w-9 items-center justify-center rounded-full shadow bg-black/50 text-white hover:bg-black/60 focus:outline-none"
+              aria-label="Next image"
+              title="Next image"
+            >
+              <svg
+                className="h-5 w-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M9 6l6 6-6 6" />
+              </svg>
+            </button>
+          </>
+        )}
+      </div>
+
+      {showThumbnails && images.length > 1 && (
+        <div
+          className="mt-2 lg:mt-0 flex lg:flex-col gap-2 overflow-x-auto lg:overflow-y-auto py-1 lg:py-0"
+          aria-label="Image thumbnails"
+        >
+          {images.map((img, i) => {
+            const active = i === current;
+            return (
+              <button
+                key={i}
+                type="button"
+                onClick={() => goTo(i)}
+                className={cn(
+                  "relative flex-shrink-0 overflow-hidden rounded-md",
+                  "w-24 h-16 lg:w-full lg:h-20",
+                  active ? "ring-2 ring-accent-500" : "ring-1 ring-black/10",
+                )}
+                aria-current={active ? "true" : "false"}
+                aria-label={`Go to image ${i + 1}`}
+              >
+                <img
+                  src={img.url}
+                  alt=""
+                  loading="lazy"
+                  decoding="async"
+                  className="h-full w-full object-cover"
+                />
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -1,27 +1,20 @@
 import React, { useState, useEffect } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import {
-  Bed,
-  Bath,
   Car,
-  MapPin,
-  Star,
   Heart,
   Phone,
   User,
-  Calendar,
-  Home as HomeIcon,
-  Square,
   ArrowLeft,
   Flame,
   Droplets,
   WashingMachine,
-  DollarSign,
 } from "lucide-react";
 import { Listing } from "../config/supabase";
 import { listingsService } from "../services/listings";
 import { useAuth } from "../hooks/useAuth";
 import { SimilarListings } from "../components/listings/SimilarListings";
+import { ImageCarousel } from "../components/media/ImageCarousel";
 
 export function ListingDetail() {
   const { id } = useParams<{ id: string }>();
@@ -30,7 +23,6 @@ export function ListingDetail() {
   const [listing, setListing] = useState<Listing | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const hasViewedRef = React.useRef(false);
 
   const getOrdinalSuffixText = (num: number): string => {
@@ -218,12 +210,21 @@ export function ListingDetail() {
     }
   };
 
-  const images =
-    listing.listing_images?.sort((a, b) => {
-      if (a.is_featured && !b.is_featured) return -1;
-      if (!a.is_featured && b.is_featured) return 1;
-      return a.sort_order - b.sort_order;
-    }) || [];
+  const carouselImages =
+    listing.listing_images
+      ?.sort((a, b) => {
+        if (a.is_featured && !b.is_featured) return -1;
+        if (!a.is_featured && b.is_featured) return 1;
+        return a.sort_order - b.sort_order;
+      })
+      .map((img) => ({ url: img.image_url, alt: listing.title })) || [];
+
+  const listedByLabel =
+    listing.owner?.agency
+      ? `Listed by ${listing.owner.agency}`
+      : listing.owner?.role
+      ? `Listed by ${getRoleLabel()}`
+      : null;
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -236,20 +237,20 @@ export function ListingDetail() {
         Back to Browse
       </Link>
 
-      {/* Image Gallery */}
-      {images.length > 0 ? (
-        <div className="mb-8">
-          {/* Main Image Viewer */}
-          <div className="relative mb-4">
-            <img
-              src={images[currentImageIndex].image_url}
-              alt={listing.title}
-              className="w-full h-96 object-contain bg-gray-100 rounded-lg"
+      <section className="space-y-8">
+        {/* Top: media + info */}
+        <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] gap-8 items-start">
+          {/* LEFT: Images */}
+          <div id="listing-media" className="relative">
+            <ImageCarousel
+              images={carouselImages}
+              fit="contain"
+              heightClass="h-[44vh] lg:h-[56vh]"
+              showThumbnails
             />
-
             <button
               onClick={handleFavoriteToggle}
-              className="absolute top-4 right-4 p-3 bg-white rounded-full shadow-lg hover:shadow-xl transition-shadow"
+              className="absolute top-4 right-4 p-3 bg-white rounded-full shadow-lg hover:shadow-xl transition-shadow z-10"
             >
               <Heart
                 className={`w-6 h-6 ${
@@ -259,347 +260,182 @@ export function ListingDetail() {
                 }`}
               />
             </button>
-
-            {images.length > 1 && (
-              <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 flex space-x-2">
-                {images.map((_, index) => (
-                  <button
-                    key={index}
-                    onClick={() => setCurrentImageIndex(index)}
-                    className={`w-3 h-3 rounded-full transition-colors ${
-                      index === currentImageIndex
-                        ? "bg-white"
-                        : "bg-white bg-opacity-50"
-                    }`}
-                  />
-                ))}
-              </div>
-            )}
           </div>
 
-          {/* Thumbnail Strip */}
-          {images.length > 1 && (
-            <div className="relative">
-              <div className="flex items-center">
-                {/* Left Arrow */}
-                <button
-                  onClick={() => {
-                    const container = document.getElementById(
-                      "thumbnail-container",
-                    );
-                    if (container) {
-                      container.scrollBy({ left: -200, behavior: "smooth" });
-                    }
-                  }}
-                  className="flex-shrink-0 p-2 mr-2 bg-white rounded-full shadow-md hover:shadow-lg transition-shadow z-10"
-                  aria-label="Scroll thumbnails left"
-                >
-                  <svg
-                    className="w-4 h-4 text-gray-600"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M15 19l-7-7 7-7"
-                    />
-                  </svg>
-                </button>
-
-                {/* Scrollable Thumbnail Container */}
-                <div
-                  id="thumbnail-container"
-                  className="flex-1 flex gap-3 overflow-x-auto scrollbar-hide scroll-smooth"
-                  style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
-                >
-                  {images.map((image, index) => (
-                    <button
-                      key={index}
-                      onClick={() => setCurrentImageIndex(index)}
-                      className={`flex-shrink-0 relative rounded-lg overflow-hidden transition-all ${
-                        index === currentImageIndex
-                          ? "ring-2 ring-[#4E4B43] shadow-md"
-                          : "hover:ring-2 hover:ring-gray-300"
-                      }`}
-                    >
-                      <img
-                        src={image.image_url}
-                        alt={`${listing.title} ${index + 1}`}
-                        className="w-20 h-16 object-contain bg-gray-50 rounded-lg"
-                      />
-                      {image.is_featured && (
-                        <div className="absolute top-1 right-1">
-                          <Star className="w-3 h-3 text-[#D29D86] fill-current drop-shadow-sm" />
-                        </div>
-                      )}
-                      {index === currentImageIndex && (
-                        <div className="absolute inset-0 bg-[#4E4B43] bg-opacity-10 rounded-lg"></div>
-                      )}
-                    </button>
-                  ))}
-                </div>
-
-                {/* Right Arrow */}
-                <button
-                  onClick={() => {
-                    const container = document.getElementById(
-                      "thumbnail-container",
-                    );
-                    if (container) {
-                      container.scrollBy({ left: 200, behavior: "smooth" });
-                    }
-                  }}
-                  className="flex-shrink-0 p-2 ml-2 bg-white rounded-full shadow-md hover:shadow-lg transition-shadow z-10"
-                  aria-label="Scroll thumbnails right"
-                >
-                  <svg
-                    className="w-4 h-4 text-gray-600"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M9 5l7 7-7 7"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          )}
-        </div>
-      ) : (
-        <div className="mb-8">
-          <div className="w-full h-96 bg-brand-50 flex items-center justify-center border border-gray-100 rounded-lg">
-            <svg
-              viewBox="0 0 24 24"
-              className="w-24 h-24 text-brand-700"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-            >
-              <path d="M3 10.5L12 3l9 7.5v9a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 19.5v-9z" />
-              <path d="M9 21V12h6v9" />
-            </svg>
-            <span className="ml-3 text-brand-700/90 text-sm">
-              No image available
-            </span>
-          </div>
-        </div>
-      )}
-
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        {/* Main Content */}
-        <div className="lg:col-span-2">
-          {/* Header */}
-          <div className="mb-6">
-            <div className="flex items-start justify-between mb-4">
-              <div>
-                <h1 className="text-3xl font-bold text-[#273140] mb-2">
+          {/* RIGHT: Info stack */}
+          <aside id="listing-info" className="flex flex-col gap-4">
+            {/* Title + tags */}
+            <div className="flex flex-col gap-2">
+              <div className="flex items-start justify-between gap-3">
+                <h1 className="text-2xl font-semibold leading-tight">
                   {listing.title}
                 </h1>
-                <div className="flex items-center text-gray-600 mb-2">
-                  <MapPin className="w-5 h-5 mr-2" />
-                  <span className="text-lg">
-                    {listing.location}
-                    {listing.neighborhood && `, ${listing.neighborhood}`}
-                  </span>
-                </div>
-                <div className="text-3xl font-bold text-[#273140]">
-                  {formatPrice(listing.price)}
-                  <span className="text-lg font-normal text-gray-500">
-                    /month
-                  </span>
-                </div>
               </div>
-
-              <div className="flex flex-wrap gap-2">
+              <div className="flex flex-wrap items-center gap-2">
                 {listing.is_featured && (
-                  <span className="inline-flex items-center bg-accent-500 text-white text-xs px-2 py-0.5 rounded">
-                    <Star className="w-3 h-3 mr-1" />
+                  <span className="inline-flex items-center rounded px-2 py-0.5 text-xs bg-accent-500 text-white">
                     Featured
                   </span>
                 )}
-                <span className="bg-[#667B9A] text-white px-3 py-1 rounded-full text-sm font-medium">
-                  {listing.owner?.role === "agent" && listing.owner?.agency
-                    ? listing.owner.agency
-                    : getRoleLabel()}
+                {listedByLabel && (
+                  <span className="inline-flex items-center rounded px-2 py-0.5 text-xs bg-muted">
+                    {listedByLabel}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {/* Location */}
+            <div>
+              <div className="text-sm text-gray-600">
+                {listing.location}
+                {listing.neighborhood && ` • ${listing.neighborhood}`}
+              </div>
+            </div>
+
+            {/* Price */}
+            <div>
+              <div className="text-2xl font-semibold">
+                {formatPrice(listing.price)}
+                <span className="text-lg font-normal text-gray-500">
+                  /month
                 </span>
+              </div>
+            </div>
+
+            {/* Basic info group */}
+            <div className="flex flex-wrap items-center gap-3 text-sm">
+              <span className="inline-flex items-center rounded bg-muted px-2 py-1">
+                {listing.bedrooms === 0 ? "Studio" : `${listing.bedrooms} bd`}
+              </span>
+              <span className="inline-flex items-center rounded bg-muted px-2 py-1">
+                {listing.bathrooms} ba
+              </span>
+              <span className="inline-flex items-center rounded bg-muted px-2 py-1">
+                {listing.broker_fee ? "Broker Fee" : "No Broker Fee"}
+              </span>
+              <span className="inline-flex items-center rounded bg-muted px-2 py-1">
+                {getPropertyTypeLabel()}
+              </span>
+            </div>
+
+            {/* Contact Information card */}
+            <div id="contact-card">
+              <div className="bg-white rounded-lg shadow-lg border border-gray-200 p-6 sticky top-8">
+                <h3 className="text-xl font-bold text-[#273140] mb-4">
+                  Contact Information
+                </h3>
+
+                <div className="space-y-4">
+                  <div className="flex items-center">
+                    <User className="w-5 h-5 text-[#273140] mr-3" />
+                    <div>
+                      <div className="font-semibold">{listing.contact_name}</div>
+                      <div className="text-sm text-gray-500">{getRoleLabel()}</div>
+                    </div>
+                  </div>
+
+                  <div className="flex items-center">
+                    <Phone className="w-5 h-5 text-[#273140] mr-3" />
+                    <a
+                      href={`tel:${listing.contact_phone}`}
+                      className="text-[#273140] hover:text-[#1e252f] font-medium transition-colors"
+                    >
+                      {formatPhoneNumber(listing.contact_phone)}
+                    </a>
+                  </div>
+                </div>
+
+                <div className="mt-6 space-y-3">
+                  <a
+                    href={`tel:${listing.contact_phone}`}
+                    className="w-full bg-[#273140] text-white py-3 px-4 rounded-md font-semibold hover:bg-[#1e252f] transition-colors flex items-center justify-center"
+                  >
+                    <Phone className="w-5 h-5 mr-2" />
+                    Call Now
+                  </a>
+
+                  <a
+                    href={`sms:${listing.contact_phone.replace(/\D/g, "")}?body=Hi, I'm interested in your listing: ${listing.title}`}
+                    className="w-full bg-accent-500 text-white py-3 px-4 rounded-md font-semibold hover:bg-accent-600 transition-colors flex items-center justify-center"
+                  >
+                    Send Message
+                  </a>
+                </div>
+
+                <div className="mt-4 pt-4 border-t border-gray-200 text-xs text-gray-500">
+                  Listed {new Date(listing.created_at).toLocaleDateString()}
+                </div>
               </div>
             </div>
 
             {/* Property Details */}
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-4 bg-gray-50 rounded-lg">
-              <div className="flex items-center">
-                <div>
-                  <div className="font-semibold">
-                    {listing.bedrooms === 0 ? "Studio" : listing.bedrooms}
-                  </div>
-                </div>
-                <Bed className="w-5 h-5 text-[#273140] ml-2" />
-              </div>
-
-              <div className="flex items-center">
-                <div>
-                  <div className="font-semibold">{listing.bathrooms}</div>
-                </div>
-                <Bath className="w-5 h-5 text-[#273140] ml-2" />
-              </div>
-
-              {listing.square_footage && (
-                <div className="flex items-center">
-                  <div>
-                    <div className="font-semibold">
-                      {formatSquareFootage(listing.square_footage)} sq ft
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              <div className="flex items-center">
-                <div>
-                  <div className="font-semibold text-sm">
-                    {getPropertyTypeLabel()}
-                  </div>
-                </div>
-                <HomeIcon className="w-5 h-5 text-[#273140] ml-2" />
+            <div id="property-details" className="p-4 bg-gray-50 rounded-lg">
+              <h3 className="font-semibold mb-3">Property Details</h3>
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                {listing.square_footage && (
+                  <div>{formatSquareFootage(listing.square_footage)} sq ft</div>
+                )}
+                <div>{getPropertyTypeLabel()}</div>
+                {listing.floor && (
+                  <div>{getOrdinalWordText(listing.floor)} Floor</div>
+                )}
+                {listing.lease_length && <div>Lease: {listing.lease_length}</div>}
               </div>
             </div>
-          </div>
 
-          {/* Description */}
-          {listing.description && (
-            <div className="mb-8">
-              <h2 className="text-2xl font-bold text-[#273140] mb-4">
-                Description
-              </h2>
-              <p className="text-gray-700 leading-relaxed whitespace-pre-wrap">
-                {listing.description}
-              </p>
-            </div>
-          )}
-
-          {/* Amenities */}
-          <div className="mb-8">
-            <h2 className="text-2xl font-bold text-[#273140] mb-4">
-              Features & Amenities
-            </h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div className="flex items-center">
-                <DollarSign className="w-5 h-5 text-[#273140] mr-3" />
-                <span>
-                  {listing.broker_fee ? "Broker Fee Applies" : "No Broker Fee"}
-                </span>
-              </div>
-
-              {listing.parking !== "no" && (
-                <div className="flex items-center">
-                  <Car className="w-5 h-5 text-[#273140] mr-3" />
-                  <span className="capitalize">
-                    {listing.parking.replace("_", " ")}
-                  </span>
-                </div>
-              )}
-
-              {listing.washer_dryer_hookup && (
-                <div className="flex items-center">
-                  <WashingMachine className="w-5 h-5 text-[#273140] mr-3" />
-                  <span>Washer/Dryer Hookup</span>
-                </div>
-              )}
-
-              {listing.dishwasher && (
-                <div className="flex items-center">
-                  <Droplets className="w-5 h-5 text-[#273140] mr-3" />
-                  <span>Dishwasher</span>
-                </div>
-              )}
-
-              <div className="flex items-center">
-                <Flame className="w-5 h-5 text-[#273140] mr-3" />
-                <span>
-                  {listing.heat === "included"
-                    ? "Heat Included"
-                    : "Tenant Pays Heat"}
-                </span>
-              </div>
-
-              {listing.floor && (
-                <div className="flex items-center">
-                  <div className="w-5 h-5 bg-[#273140] rounded mr-3 flex items-center justify-center">
-                    <span className="text-white text-xs font-bold">
-                      {listing.floor}
+            {/* Amenities */}
+            <div id="amenities">
+              <h3 className="text-xl font-bold text-[#273140] mb-4">Amenities</h3>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {listing.parking !== "no" && (
+                  <div className="flex items-center">
+                    <Car className="w-5 h-5 text-[#273140] mr-3" />
+                    <span className="capitalize">
+                      {listing.parking.replace("_", " ")}
                     </span>
                   </div>
-                  <span>{getOrdinalWordText(listing.floor)} Floor</span>
-                </div>
-              )}
+                )}
 
-              {listing.lease_length && (
+                {listing.washer_dryer_hookup && (
+                  <div className="flex items-center">
+                    <WashingMachine className="w-5 h-5 text-[#273140] mr-3" />
+                    <span>Washer/Dryer Hookup</span>
+                  </div>
+                )}
+
+                {listing.dishwasher && (
+                  <div className="flex items-center">
+                    <Droplets className="w-5 h-5 text-[#273140] mr-3" />
+                    <span>Dishwasher</span>
+                  </div>
+                )}
+
                 <div className="flex items-center">
-                  <Calendar className="w-5 h-5 text-[#273140] mr-3" />
-                  <span>Lease: {listing.lease_length}</span>
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-
-        {/* Contact Card */}
-        <div className="lg:col-span-1">
-          <div className="bg-white rounded-lg shadow-lg border border-gray-200 p-6 sticky top-8">
-            <h3 className="text-xl font-bold text-[#273140] mb-4">
-              Contact Information
-            </h3>
-
-            <div className="space-y-4">
-              <div className="flex items-center">
-                <User className="w-5 h-5 text-[#273140] mr-3" />
-                <div>
-                  <div className="font-semibold">{listing.contact_name}</div>
-                  <div className="text-sm text-gray-500">{getRoleLabel()}</div>
+                  <Flame className="w-5 h-5 text-[#273140] mr-3" />
+                  <span>
+                    {listing.heat === "included"
+                      ? "Heat Included"
+                      : "Tenant Pays Heat"}
+                  </span>
                 </div>
               </div>
-
-              <div className="flex items-center">
-                <Phone className="w-5 h-5 text-[#273140] mr-3" />
-                <a
-                  href={`tel:${listing.contact_phone}`}
-                  className="text-[#273140] hover:text-[#1e252f] font-medium transition-colors"
-                >
-                  {formatPhoneNumber(listing.contact_phone)}
-                </a>
-              </div>
             </div>
-
-            <div className="mt-6 space-y-3">
-              <a
-                href={`tel:${listing.contact_phone}`}
-                className="w-full bg-[#273140] text-white py-3 px-4 rounded-md font-semibold hover:bg-[#1e252f] transition-colors flex items-center justify-center"
-              >
-                <Phone className="w-5 h-5 mr-2" />
-                Call Now
-              </a>
-
-              <a
-                href={`sms:${listing.contact_phone.replace(/\D/g, "")}?body=Hi, I'm interested in your listing: ${listing.title}`}
-                className="w-full bg-accent-500 text-white py-3 px-4 rounded-md font-semibold hover:bg-accent-600 transition-colors flex items-center justify-center"
-              >
-                Send Message
-              </a>
-            </div>
-
-            <div className="mt-4 pt-4 border-t border-gray-200 text-xs text-gray-500">
-              Listed {new Date(listing.created_at).toLocaleDateString()}
-            </div>
-          </div>
+          </aside>
         </div>
-      </div>
+
+        {/* Description below both columns */}
+        {listing.description && (
+          <div id="description" className="prose max-w-none">
+            <h2 className="text-2xl font-bold text-[#273140] mb-4">
+              Description
+            </h2>
+            <p className="text-gray-700 leading-relaxed whitespace-pre-wrap">
+              {listing.description}
+            </p>
+          </div>
+        )}
+      </section>
 
       {/* Similar Listings */}
       <SimilarListings listing={listing} />


### PR DESCRIPTION
## Summary
- refactor listing detail hero into responsive grid with carousel media and stacked property information
- show featured/listed-by badges and embed contact card, details, and amenities on the right

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ca8da3c888329a11afec1d9c8136b