### PR TITLE
Use environment-driven URLs for auth reset flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Layout } from './components/shared/Layout';
 import { Home } from './pages/Home';
 import { BrowseListings } from './pages/BrowseListings';
 import { AuthForm } from './components/auth/AuthForm';
+import PasswordRecoveryGate from './components/auth/PasswordRecoveryGate';
 import { PostListing } from './pages/PostListing';
 import { EditListing } from './pages/EditListing';
 import { ListingDetail } from './pages/ListingDetail';
@@ -67,7 +68,14 @@ function App() {
                 <Route path="/contact" element={<Contact />} />
                 <Route path="/privacy" element={<Privacy />} />
                 <Route path="/terms" element={<Terms />} />
-                <Route path="/auth" element={<AuthForm />} />
+                <Route
+                  path="/auth"
+                  element={
+                    <PasswordRecoveryGate onSuccessPath="/">
+                      <AuthForm />
+                    </PasswordRecoveryGate>
+                  }
+                />
                 <Route path="*" element={<Navigate to="/" replace />} />
               </Routes>
             </Layout>

--- a/src/components/auth/PasswordRecoveryGate.tsx
+++ b/src/components/auth/PasswordRecoveryGate.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/config/supabase";
+
+type PasswordRecoveryGateProps = {
+  children: React.ReactNode;
+  onSuccessPath?: string;
+};
+
+export default function PasswordRecoveryGate({
+  children,
+  onSuccessPath = "/",
+}: PasswordRecoveryGateProps) {
+  const navigate = useNavigate();
+  const [mode, setMode] = useState<"normal" | "recover" | "updating" | "done">(
+    "normal",
+  );
+  const [err, setErr] = useState<string | null>(null);
+  const [pw1, setPw1] = useState("");
+  const [pw2, setPw2] = useState("");
+
+  const isUrlRecovery = useMemo(() => {
+    try {
+      const url = new URL(window.location.href);
+      const qType = url.searchParams.get("type");
+      const hashType = new URLSearchParams((url.hash || "").replace(/^#/, "")).get(
+        "type",
+      );
+      return qType === "recovery" || hashType === "recovery";
+    } catch {
+      return false;
+    }
+  }, []);
+
+  useEffect(() => {
+    const { data: sub } = supabase.auth.onAuthStateChange((event) => {
+      if (event === "PASSWORD_RECOVERY") setMode("recover");
+    });
+    if (isUrlRecovery) setMode("recover");
+    return () => sub?.subscription?.unsubscribe?.();
+  }, [isUrlRecovery]);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErr(null);
+    if (pw1.length < 8) {
+      setErr("Password must be at least 8 characters.");
+      return;
+    }
+    if (pw1 !== pw2) {
+      setErr("Passwords do not match.");
+      return;
+    }
+    setMode("updating");
+    const { error } = await supabase.auth.updateUser({ password: pw1 });
+    if (error) {
+      setMode("recover");
+      setErr(error.message || "Failed to update password.");
+      return;
+    }
+    setMode("done");
+    setTimeout(() => navigate(onSuccessPath), 800);
+  };
+
+  if (mode !== "recover" && mode !== "updating" && mode !== "done") {
+    return <>{children}</>;
+  }
+
+  if (mode === "done") {
+    return (
+      <div className="max-w-md mx-auto p-6">
+        <h1 className="text-xl font-semibold mb-2">Password updated</h1>
+        <p className="text-sm text-gray-600">Redirecting…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-md mx-auto p-6">
+      <h1 className="text-2xl font-semibold mb-4">Reset your password</h1>
+      <p className="text-sm text-gray-600 mb-4">
+        Enter a new password for your account.
+      </p>
+      <form onSubmit={onSubmit} className="space-y-3">
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            New password
+          </label>
+          <input
+            type="password"
+            className="w-full border rounded-md px-3 py-2"
+            value={pw1}
+            onChange={(e) => setPw1(e.target.value)}
+            required
+            autoComplete="new-password"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Confirm password
+          </label>
+          <input
+            type="password"
+            className="w-full border rounded-md px-3 py-2"
+            value={pw2}
+            onChange={(e) => setPw2(e.target.value)}
+            required
+            autoComplete="new-password"
+          />
+        </div>
+        {err && <p className="text-sm text-red-600">{err}</p>}
+        <button
+          type="submit"
+          disabled={mode === "updating"}
+          className="w-full rounded-md px-3 py-2 border font-semibold disabled:opacity-60"
+        >
+          {mode === "updating" ? "Saving…" : "Save new password"}
+        </button>
+      </form>
+    </div>
+  );
+}
+

--- a/src/lib/ga.ts
+++ b/src/lib/ga.ts
@@ -24,7 +24,9 @@ export function gaEvent(eventName: string, params: Params = {}): void {
     try {
       gtag("event", eventName, params);
       return;
-    } catch {}
+    } catch (_) {
+      // noop
+    }
   }
   // Fallback: still emit something GTM/GA can pick up later
   pushDataLayer({ event: eventName, ...params });

--- a/src/lib/siteUrl.ts
+++ b/src/lib/siteUrl.ts
@@ -1,0 +1,8 @@
+export const getSiteUrl = () => {
+  const url =
+    import.meta?.env?.VITE_PUBLIC_SITE_URL ||
+    window?.location?.origin ||
+    'http://localhost:5173';
+  // ensure no trailing slash
+  return url.replace(new RegExp('/+$'), '');
+};

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -101,7 +101,9 @@ Deno.serve(async (req) => {
         const resetEmail = Array.isArray(emailData.to)
           ? emailData.to[0]
           : emailData.to;
-        const redirectUrl = `${Deno.env.get("VITE_SITE_URL") || "http://localhost:5173"}/auth`;
+        const PUBLIC_SITE_URL =
+          Deno.env.get('PUBLIC_SITE_URL') || 'http://localhost:5173';
+        const redirectUrl = `${PUBLIC_SITE_URL.replace(new RegExp('/+$'), '')}/auth`;
 
         console.log("🔗 Generating reset link with params:", {
           email: resetEmail,

--- a/supabase/functions/send-password-reset/index.ts
+++ b/supabase/functions/send-password-reset/index.ts
@@ -49,7 +49,9 @@ Deno.serve(async (req) => {
       },
     });
 
-    const redirectUrl = `${Deno.env.get("VITE_SITE_URL") || "http://localhost:5173"}/auth`;
+    const PUBLIC_SITE_URL =
+      Deno.env.get('PUBLIC_SITE_URL') || 'http://localhost:5173';
+    const redirectUrl = `${PUBLIC_SITE_URL.replace(new RegExp('/+$'), '')}/auth`;
     const email = Array.isArray(to) ? to[0] : to;
 
     const { data, error: linkError } =


### PR DESCRIPTION
## Summary
- add helper to read site URL from env or window
- use PUBLIC_SITE_URL in edge functions to build password reset redirect links
- tidy GA helper catch block
- show password reset form when arriving from Supabase recovery link

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1f271e91c8329a9d486bf966c79be