### PR TITLE
feat: enforce lining digits for numeric UI

### DIFF
--- a/src/components/listings/ListingCard.tsx
+++ b/src/components/listings/ListingCard.tsx
@@ -73,8 +73,6 @@ export function ListingCard({
 
   const formatPrice = (price: number) => {
     return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
       minimumFractionDigits: 0,
       maximumFractionDigits: 0,
     }).format(price);
@@ -135,20 +133,23 @@ export function ListingCard({
         {/* Price */}
         <div className="mb-2">
           <span className="text-2xl leading-tight font-bold text-brand-900">
-            {formatPrice(listing.price)}
+            $
+            <span className="num-clean">{formatPrice(listing.price)}</span>
           </span>
         </div>
 
         {/* Property specs - bedrooms, bathrooms, parking, broker fee */}
         <div className="flex items-center text-gray-600 mb-2">
           <div className="flex items-center mr-3">
-            <span className="text-sm mr-1">
-              {listing.bedrooms === 0 ? "Studio" : listing.bedrooms}
-            </span>
+            {listing.bedrooms === 0 ? (
+              <span className="text-sm mr-1">Studio</span>
+            ) : (
+              <span className="text-sm mr-1 num-clean">{listing.bedrooms}</span>
+            )}
             <Bed className="w-4 h-4" />
           </div>
           <div className="flex items-center mr-3">
-            <span className="text-sm mr-1">{listing.bathrooms}</span>
+            <span className="text-sm mr-1 num-clean">{listing.bathrooms}</span>
             <Bath className="w-4 h-4" />
           </div>
           {hasParking && (

--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -785,7 +785,10 @@ export function AdminPanel() {
                       <div key={listing.id} className="flex items-center justify-between">
                         <div>
                           <p className="font-medium truncate">{listing.title}</p>
-                          <p className="text-sm text-gray-500">${listing.price}/month</p>
+                          <p className="text-sm text-gray-500">
+                            $<span className="num-clean">{listing.price.toLocaleString()}</span>
+                            /month
+                          </p>
                         </div>
                         <span className={`px-2 py-1 text-xs rounded-full ${
                           listing.is_featured ? 'bg-yellow-100 text-yellow-800' : 'bg-gray-100 text-gray-800'
@@ -1350,7 +1353,8 @@ export function AdminPanel() {
                             </div>
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                            ${listing.price}/month
+                            $<span className="num-clean">{listing.price.toLocaleString()}</span>
+                            /month
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                             {new Date(listing.created_at).toLocaleDateString()}
@@ -1546,7 +1550,13 @@ export function AdminPanel() {
                                 {listing.title}
                               </div>
                               <div className="text-sm text-gray-500">
-                                {listing.bedrooms === 0 ? 'Studio' : `${listing.bedrooms} bed`}, {listing.bathrooms} bath
+                                {listing.bedrooms === 0 ? (
+                                  'Studio'
+                                ) : (
+                                  <>
+                                    <span className="num-clean">{listing.bedrooms}</span> bed
+                                  </>
+                                )}, <span className="num-clean">{listing.bathrooms}</span> bath
                               </div>
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap">
@@ -1554,7 +1564,7 @@ export function AdminPanel() {
                               <div className="text-sm text-gray-500 capitalize">{listing.owner?.role || 'N/A'}</div>
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                              ${listing.price.toLocaleString()}/month
+                              $<span className="num-clean">{listing.price.toLocaleString()}</span>/month
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                               {new Date(listing.created_at).toLocaleDateString()}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -275,8 +275,6 @@ export default function Dashboard() {
 
   const formatPrice = (price: number) => {
     return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
       minimumFractionDigits: 0,
       maximumFractionDigits: 0,
     }).format(price);
@@ -444,18 +442,21 @@ export default function Dashboard() {
                                 {listing.title}
                               </Link>
                               <div className="text-sm text-gray-500 truncate">
-                                {listing.bedrooms} bed, {listing.bathrooms} bath
+                                <span className="num-clean">{listing.bedrooms}</span> bed,{' '}
+                                <span className="num-clean">{listing.bathrooms}</span> bath
                               </div>
                             </div>
                           </div>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                          {formatPrice(listing.price)}/month
+                          $
+                          <span className="num-clean">{formatPrice(listing.price)}</span>
+                          /month
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-center">
                           <div className="flex items-center text-sm text-gray-900">
                             <Eye className="w-4 h-4 mr-1 text-gray-400" />
-                            {listing.views || 0}
+                            <span className="num-clean">{listing.views || 0}</span>
                           </div>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap">

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -256,8 +256,6 @@ export function ListingDetail() {
 
   const formatPrice = (price: number) => {
     return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
       minimumFractionDigits: 0,
       maximumFractionDigits: 0,
     }).format(price);
@@ -395,7 +393,8 @@ export function ListingDetail() {
           {/* Price */}
           <section id="ld-price">
             <div className="text-3xl font-bold text-[#273140]">
-              {formatPrice(listing.price)}
+              $
+              <span className="num-clean">{formatPrice(listing.price)}</span>
               <span className="text-lg font-normal text-gray-500">
                 /month
               </span>
@@ -408,7 +407,11 @@ export function ListingDetail() {
               <div className="flex items-center">
                 <div>
                   <div className="font-semibold">
-                    {listing.bedrooms === 0 ? "Studio" : listing.bedrooms}
+                    {listing.bedrooms === 0 ? (
+                      "Studio"
+                    ) : (
+                      <span className="num-clean">{listing.bedrooms}</span>
+                    )}
                   </div>
                 </div>
                 <Bed className="w-5 h-5 text-[#273140] ml-2" />
@@ -416,7 +419,9 @@ export function ListingDetail() {
 
               <div className="flex items-center">
                 <div>
-                  <div className="font-semibold">{listing.bathrooms}</div>
+                  <div className="font-semibold">
+                    <span className="num-clean">{listing.bathrooms}</span>
+                  </div>
                 </div>
                 <Bath className="w-5 h-5 text-[#273140] ml-2" />
               </div>
@@ -425,7 +430,10 @@ export function ListingDetail() {
                 <div className="flex items-center">
                   <div>
                     <div className="font-semibold">
-                      {formatSquareFootage(listing.square_footage)} sq ft
+                      <span className="num-clean">
+                        {formatSquareFootage(listing.square_footage)}
+                      </span>{" "}
+                      sq ft
                     </div>
                   </div>
                 </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -47,3 +47,16 @@ h6,
 .scrollbar-hide::-webkit-scrollbar {
   display: none;
 }
+
+/* -- Numeric utility to force lining + tabular digits (with OpenType fallback) -- */
+.num-clean {
+  font-variant-numeric: lining-nums tabular-nums;
+  /* Fallback for browsers/fonts that ignore font-variant-numeric: */
+  font-feature-settings: "lnum" 1, "tnum" 1;
+}
+
+/* Optional: if the brand serif truly lacks lining figures, uncomment the next line
+   to temporarily switch numerals to the UI sans only for numbers.
+   Keep it commented unless needed after testing.
+*/
+/* .num-clean { font-family: var(--ui-sans, ui-sans-serif, system-ui, -apple-system, "Inter", "Segoe UI"); } */


### PR DESCRIPTION
## Summary
- add `.num-clean` utility class for lining and tabular numerals
- wrap prices and counts with `.num-clean` spans across listing components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1f8b7f5408329b15aeb5b198c9033