### PR TITLE
feat: dynamic agency filter for browse listings

### DIFF
--- a/src/components/listings/ListingCard.tsx
+++ b/src/components/listings/ListingCard.tsx
@@ -66,10 +66,28 @@ export function ListingCard({
   };
 
   const getPosterLabel = () => {
-    if (listing.owner?.role === "agent" && listing.owner?.agency) {
-      return capitalizeName(listing.owner?.agency || "");
+    const role =
+      listing?.owner?.role ??
+      (listing as any)?.profiles?.role ??
+      listing?.poster_role ??
+      (listing as any)?.poster_type ??
+      null;
+
+    const agency =
+      listing?.owner?.agency ??
+      (listing as any)?.profiles?.agency ??
+      listing?.poster_agency ??
+      null;
+
+    if (role === "agent") {
+      return agency && agency.trim() ? capitalizeName(agency) : "Agent";
     }
-    return "Owner";
+
+    if (role === "landlord" || role === "tenant") {
+      return "Owner";
+    }
+
+    return agency && agency.trim() ? capitalizeName(agency) : "Listing";
   };
 
   const formatPrice = (price: number) => {

--- a/src/components/listings/ListingFilters.tsx
+++ b/src/components/listings/ListingFilters.tsx
@@ -6,6 +6,7 @@ interface FilterState {
   bedrooms?: number;
   poster_type?: string;
   agency_name?: string;
+  whoListing?: string;
   property_type?: string;
   min_price?: number;
   max_price?: number;
@@ -17,7 +18,7 @@ interface FilterState {
 interface ListingFiltersProps {
   filters: FilterState;
   onFiltersChange: (filters: FilterState) => void;
-  agencies: string[];
+  agencies?: string[];
   allNeighborhoods?: string[];
   isMobile?: boolean;
 }
@@ -25,7 +26,7 @@ interface ListingFiltersProps {
 export function ListingFilters({
   filters,
   onFiltersChange,
-  agencies,
+  agencies = [],
   allNeighborhoods = [],
   isMobile = false,
 }: ListingFiltersProps) {
@@ -133,14 +134,24 @@ export function ListingFilters({
             Who is Listing?
           </label>
           <select
-            value={filters.poster_type || ""}
+            value={filters.whoListing || ""}
             onChange={(e) => {
-              const newPosterType = e.target.value;
-              const newFilters = { ...filters, poster_type: newPosterType };
+              const value = e.target.value;
+              const newFilters = { ...filters, whoListing: value || undefined } as FilterState;
 
-              // Clear agency_name if not selecting 'agency'
-              if (newPosterType !== "agency") {
+              // Map to legacy fields for backward compatibility
+              if (!value) {
+                delete newFilters.poster_type;
                 delete newFilters.agency_name;
+              } else if (value === "owner") {
+                newFilters.poster_type = "owner";
+                delete newFilters.agency_name;
+              } else if (value === "agent:any") {
+                newFilters.poster_type = "agent";
+                delete newFilters.agency_name;
+              } else if (value.startsWith("agent:")) {
+                newFilters.poster_type = "agent";
+                newFilters.agency_name = value.replace("agent:", "");
               }
 
               onFiltersChange(newFilters);
@@ -148,33 +159,19 @@ export function ListingFilters({
             className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-[#273140] focus:border-[#273140]"
           >
             <option value="">All Posters</option>
-            <option value="landlord">Landlord</option>
-            <option value="agency">Agency</option>
+            <option value="owner">All Owners</option>
+            <option value="agent:any">All Agents</option>
+            {agencies.length > 0 && (
+              <optgroup label="Specific Agencies">
+                {agencies.map((agency) => (
+                  <option key={agency} value={`agent:${agency}`}>
+                    {agency}
+                  </option>
+                ))}
+              </optgroup>
+            )}
           </select>
         </div>
-
-        {/* Agency Name - only show when poster_type is 'agency' */}
-        {filters.poster_type === "agency" && (
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Agency Name
-            </label>
-            <select
-              value={filters.agency_name || ""}
-              onChange={(e) =>
-                handleFilterChange("agency_name", e.target.value)
-              }
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-[#273140] focus:border-[#273140]"
-            >
-              <option value="">All Agencies</option>
-              {agencies.map((agency) => (
-                <option key={agency} value={agency}>
-                  {agency}
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
 
         {/* Neighborhoods */}
         <div>

--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -61,6 +61,8 @@ export interface Listing {
   approved: boolean;
   owner?: Profile;
   listing_images?: ListingImage[];
+  poster_role?: string;
+  poster_agency?: string;
   is_favorited?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- support `whoListing` parameter with owner/agent/agency options
- fetch active agencies via Supabase and expose new helper
- replace "Who is Listing" UI with dynamic agency options and DB-level filtering
- always apply active & approved constraints so poster/agency filters apply for authenticated users
- ensure poster role/agency are returned and used for card labels
- normalize poster type values across UI, URL, and service so role/agency filters work correctly

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf1edeb8d4832988ea70397c151e90