### PR TITLE
Implement call-for-price option for listings

### DIFF
--- a/src/components/listings/ListingCard.tsx
+++ b/src/components/listings/ListingCard.tsx
@@ -137,9 +137,17 @@ export function ListingCard({
       <div className="p-3">
         {/* Price */}
         <div className="mb-2">
-          <span className="text-2xl leading-tight font-bold text-brand-900">
-            <span className="num-font">{formatPrice(listing.price)}</span>
-          </span>
+          {listing.call_for_price ? (
+            <strong className="text-2xl leading-tight font-bold text-brand-900">
+              Call for Price
+            </strong>
+          ) : (
+            listing.price != null && (
+              <span className="text-2xl leading-tight font-bold text-brand-900">
+                <span className="num-font">{formatPrice(listing.price)}</span>
+              </span>
+            )
+          )}
         </div>
 
         {/* Property specs - bedrooms, bathrooms, parking, broker fee */}

--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -40,7 +40,8 @@ export interface Listing {
   bedrooms: number;
   bathrooms: number;
   floor?: number;
-  price: number;
+  price: number | null;
+  call_for_price?: boolean;
   square_footage?: number;
   parking: ParkingType;
   washer_dryer_hookup: boolean;

--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -159,8 +159,8 @@ export function AdminPanel() {
           bValue = (b.owner?.full_name || '').toLowerCase();
           break;
         case 'price':
-          aValue = a.price;
-          bValue = b.price;
+          aValue = a.price ?? 0;
+          bValue = b.price ?? 0;
           break;
         case 'created_at':
           aValue = new Date(a.created_at).getTime();
@@ -785,7 +785,9 @@ export function AdminPanel() {
                       <div key={listing.id} className="flex items-center justify-between">
                         <div>
                           <p className="font-medium truncate">{listing.title}</p>
-                          <p className="text-sm text-gray-500">${listing.price}/month</p>
+                          <p className="text-sm text-gray-500">
+                            {listing.call_for_price ? 'Call for Price' : `$${listing.price}/month`}
+                          </p>
                         </div>
                         <span className={`px-2 py-1 text-xs rounded-full ${
                           listing.is_featured ? 'bg-yellow-100 text-yellow-800' : 'bg-gray-100 text-gray-800'
@@ -1350,7 +1352,7 @@ export function AdminPanel() {
                             </div>
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                            ${listing.price}/month
+                            {listing.call_for_price ? 'Call for Price' : `$${listing.price}/month`}
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                             {new Date(listing.created_at).toLocaleDateString()}
@@ -1554,7 +1556,9 @@ export function AdminPanel() {
                               <div className="text-sm text-gray-500 capitalize">{listing.owner?.role || 'N/A'}</div>
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                              ${listing.price.toLocaleString()}/month
+                              {listing.call_for_price
+                                ? 'Call for Price'
+                                : `$${listing.price.toLocaleString()}/month`}
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                               {new Date(listing.created_at).toLocaleDateString()}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -273,7 +273,8 @@ export default function Dashboard() {
     }
   };
 
-  const formatPrice = (price: number) => {
+  const formatPrice = (price: number | null) => {
+    if (price == null) return "";
     return new Intl.NumberFormat("en-US", {
       style: "currency",
       currency: "USD",
@@ -450,7 +451,9 @@ export default function Dashboard() {
                           </div>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                          {formatPrice(listing.price)}/month
+                          {listing.call_for_price
+                            ? 'Call for Price'
+                            : `${formatPrice(listing.price)}/month`}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-center">
                           <div className="flex items-center text-sm text-gray-900">

--- a/src/pages/EditListing.tsx
+++ b/src/pages/EditListing.tsx
@@ -22,7 +22,8 @@ interface ListingFormData {
   bedrooms: number;
   bathrooms: number;
   floor?: number;
-  price: number;
+  price: number | null;
+  call_for_price: boolean;
   square_footage?: number;
   parking: ParkingType;
   washer_dryer_hookup: boolean;
@@ -67,7 +68,8 @@ export function EditListing() {
     bedrooms: 1,
     bathrooms: 1,
     floor: undefined,
-    price: 0,
+    price: null,
+    call_for_price: false,
     square_footage: undefined,
     parking: "no",
     washer_dryer_hookup: false,
@@ -118,7 +120,8 @@ export function EditListing() {
         bedrooms: data.bedrooms,
         bathrooms: data.bathrooms,
         floor: data.floor || undefined,
-        price: data.price,
+        price: data.call_for_price ? null : data.price,
+        call_for_price: !!data.call_for_price,
         square_footage: data.square_footage || undefined,
         parking: data.parking,
         washer_dryer_hookup: data.washer_dryer_hookup,
@@ -393,6 +396,8 @@ export function EditListing() {
         ...formData,
         neighborhood,
         updated_at: new Date().toISOString(),
+        price: formData.call_for_price ? null : formData.price,
+        call_for_price: !!formData.call_for_price,
       } as any);
 
       // Upload new images
@@ -638,13 +643,34 @@ export function EditListing() {
               </label>
               <input
                 type="number"
-                name="price"
-                value={formData.price || ""}
-                onChange={handleInputChange}
-                required
+                min={1}
+                step={1}
+                value={formData.price ?? ''}
+                onChange={(e) =>
+                  setFormData((f) => ({
+                    ...f,
+                    price: e.target.value ? Number(e.target.value) : null,
+                  }))
+                }
+                disabled={formData.call_for_price}
+                required={!formData.call_for_price}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-[#273140] focus:border-[#273140]"
                 placeholder="2500"
               />
+              <label className="flex items-center gap-2 mt-2">
+                <input
+                  type="checkbox"
+                  checked={formData.call_for_price}
+                  onChange={(e) =>
+                    setFormData((f) => ({
+                      ...f,
+                      call_for_price: e.target.checked,
+                      price: e.target.checked ? null : f.price,
+                    }))
+                  }
+                />
+                <span>Call for Price</span>
+              </label>
             </div>
 
             <div>

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -409,12 +409,16 @@ export function ListingDetail() {
 
           {/* Price */}
           <section id="ld-price">
-            <div className="text-3xl font-bold text-[#273140]">
-              <span className="num-font">{formatPrice(listing.price)}</span>
-              <span className="text-lg font-normal text-gray-500">
-                /month
-              </span>
-            </div>
+            {listing.call_for_price ? (
+              <strong>Call for Price</strong>
+            ) : (
+              listing.price != null && (
+                <div className="text-3xl font-bold text-[#273140]">
+                  <span className="num-font">{formatPrice(listing.price)}</span>
+                  <span className="text-lg font-normal text-gray-500">/month</span>
+                </div>
+              )
+            )}
           </section>
 
           {/* Basic info */}

--- a/src/services/draftListings.ts
+++ b/src/services/draftListings.ts
@@ -9,7 +9,8 @@ export interface DraftData {
   bedrooms: number;
   bathrooms: number;
   floor?: number;
-  price: number;
+  price: number | null;
+  call_for_price: boolean;
   square_footage?: number;
   parking: string;
   washer_dryer_hookup: boolean;


### PR DESCRIPTION
## Summary
- support nullable prices and a `call_for_price` flag in listing types and service payloads
- add checkbox to create/edit forms to disable price and send normalized data
- display **Call for Price** on cards, details, and admin/dashboard views when flagged

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c212e188c08329bdea43a9f4873b74