### PR TITLE
Add agency filter and dynamic listing dropdown

### DIFF
--- a/src/components/listings/ListingFilters.tsx
+++ b/src/components/listings/ListingFilters.tsx
@@ -17,7 +17,7 @@ interface FilterState {
 interface ListingFiltersProps {
   filters: FilterState;
   onFiltersChange: (filters: FilterState) => void;
-  agencies: string[];
+  agencies?: string[];
   allNeighborhoods?: string[];
   isMobile?: boolean;
 }
@@ -25,7 +25,7 @@ interface ListingFiltersProps {
 export function ListingFilters({
   filters,
   onFiltersChange,
-  agencies,
+  agencies = [],
   allNeighborhoods = [],
   isMobile = false,
 }: ListingFiltersProps) {
@@ -69,6 +69,22 @@ export function ListingFilters({
 
   const clearFilters = () => {
     onFiltersChange({});
+  };
+
+  const onWhoChange = (value: string) => {
+    if (value === 'owner') {
+      onFiltersChange({ ...filters, poster_type: 'owner', agency_name: undefined });
+    } else if (value === 'agent:any') {
+      onFiltersChange({ ...filters, poster_type: 'agent', agency_name: undefined });
+    } else if (value.startsWith('agent:')) {
+      onFiltersChange({
+        ...filters,
+        poster_type: 'agent',
+        agency_name: value.slice('agent:'.length),
+      });
+    } else {
+      onFiltersChange({ ...filters, poster_type: undefined, agency_name: undefined });
+    }
   };
 
   return (
@@ -133,48 +149,32 @@ export function ListingFilters({
             Who is Listing?
           </label>
           <select
-            value={filters.poster_type || ""}
-            onChange={(e) => {
-              const newPosterType = e.target.value;
-              const newFilters = { ...filters, poster_type: newPosterType };
-
-              // Clear agency_name if not selecting 'agency'
-              if (newPosterType !== "agency") {
-                delete newFilters.agency_name;
-              }
-
-              onFiltersChange(newFilters);
-            }}
+            value={
+              filters.poster_type === 'owner'
+                ? 'owner'
+                : filters.poster_type === 'agent'
+                  ? filters.agency_name
+                    ? `agent:${filters.agency_name}`
+                    : 'agent:any'
+                  : ''
+            }
+            onChange={(e) => onWhoChange(e.target.value)}
             className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-[#273140] focus:border-[#273140]"
           >
             <option value="">All Posters</option>
-            <option value="landlord">Landlord</option>
-            <option value="agency">Agency</option>
+            <option value="owner">All Landlords</option>
+            <option value="agent:any">All Agencies</option>
+            {agencies.length > 0 && (
+              <optgroup label="Specific Agencies">
+                {agencies.map((agency) => (
+                  <option key={agency} value={`agent:${agency}`}>
+                    {agency}
+                  </option>
+                ))}
+              </optgroup>
+            )}
           </select>
         </div>
-
-        {/* Agency Name - only show when poster_type is 'agency' */}
-        {filters.poster_type === "agency" && (
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Agency Name
-            </label>
-            <select
-              value={filters.agency_name || ""}
-              onChange={(e) =>
-                handleFilterChange("agency_name", e.target.value)
-              }
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-[#273140] focus:border-[#273140]"
-            >
-              <option value="">All Agencies</option>
-              {agencies.map((agency) => (
-                <option key={agency} value={agency}>
-                  {agency}
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
 
         {/* Neighborhoods */}
         <div>


### PR DESCRIPTION
## Summary
- fetch active agency names with new `getActiveAgencies`
- harden listing retrieval with poster type and agency filters
- add dynamic "Who is Listing" dropdown with agency options
- load agencies once on browse page and pass to filters

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c21adf413483298e9d109c9e7e5bf0