### PR TITLE
Block broker-fee listings and reset toggle

### DIFF
--- a/src/pages/EditListing.tsx
+++ b/src/pages/EditListing.tsx
@@ -131,7 +131,7 @@ export function EditListing() {
         property_type: data.property_type,
         contact_name: data.contact_name,
         contact_phone: data.contact_phone,
-        broker_fee: data.broker_fee,
+        broker_fee: false,
       });
       // Check if using custom neighborhood
       const standardNeighborhoods = [
@@ -172,6 +172,15 @@ export function EditListing() {
 
     if (type === "checkbox") {
       const checked = (e.target as HTMLInputElement).checked;
+      if (name === "broker_fee") {
+        if (checked) {
+          alert(
+            "Listings with a tenant broker fee are not permitted on HaDirot. Please remove the fee to proceed.",
+          );
+        }
+        setFormData((prev) => ({ ...prev, broker_fee: false }));
+        return;
+      }
       setFormData((prev) => ({ ...prev, [name]: checked }));
     } else if (type === "number") {
       const numValue = value === "" ? undefined : parseFloat(value);
@@ -370,6 +379,14 @@ export function EditListing() {
         return;
       }
 
+      if (formData.broker_fee) {
+        alert(
+          "Listings with a tenant broker fee are not permitted on HaDirot. Please remove the fee to proceed.",
+        );
+        setSaving(false);
+        return;
+      }
+
       // Delete marked images first
       for (const imageId of imagesToDelete) {
         const imageToDelete = existingImages.find((img) => img.id === imageId);
@@ -394,6 +411,7 @@ export function EditListing() {
       // Update the listing
       await listingsService.updateListing(id, {
         ...formData,
+        broker_fee: false,
         neighborhood,
         updated_at: new Date().toISOString(),
         price: formData.call_for_price ? null : formData.price,

--- a/src/pages/PostListing.tsx
+++ b/src/pages/PostListing.tsx
@@ -190,7 +190,7 @@ export function PostListing() {
           contact_name: draftData.contact_name || profile?.full_name || "",
           contact_phone: draftData.contact_phone || profile?.phone || "",
           is_featured: draftData.is_featured || false,
-          broker_fee: draftData.broker_fee || false,
+          broker_fee: false,
         });
 
         // Restore temp images if they exist
@@ -232,7 +232,7 @@ export function PostListing() {
   const saveDraftData = async (identifier: string) => {
     setSavingDraft(true);
     try {
-      const draftData: DraftData = formData;
+      const draftData: DraftData = { ...formData, broker_fee: false };
 
       await draftListingsService.saveDraft(draftData, identifier, tempImages);
       console.log("✅ Draft saved automatically for:", identifier);
@@ -255,6 +255,15 @@ export function PostListing() {
 
     if (type === "checkbox") {
       const checked = (e.target as HTMLInputElement).checked;
+      if (name === "broker_fee") {
+        if (checked) {
+          alert(
+            "Listings with a tenant broker fee are not permitted on HaDirot. Please remove the fee to proceed.",
+          );
+        }
+        setFormData((prev) => ({ ...prev, broker_fee: false }));
+        return;
+      }
       setFormData((prev) => ({ ...prev, [name]: checked }));
     } else if (type === "number") {
       const numValue = value === "" ? undefined : parseFloat(value);
@@ -405,8 +414,16 @@ export function PostListing() {
           ? customNeighborhoodInput.trim()
           : neighborhoodSelectValue;
 
-      if (neighborhoodSelectValue === "other" && neighborhood === "") {
-        alert("Please enter a neighborhood");
+    if (neighborhoodSelectValue === "other" && neighborhood === "") {
+      alert("Please enter a neighborhood");
+      setLoading(false);
+      return;
+    }
+
+      if (formData.broker_fee) {
+        alert(
+          "Listings with a tenant broker fee are not permitted on HaDirot. Please remove the fee to proceed.",
+        );
         setLoading(false);
         return;
       }
@@ -417,6 +434,7 @@ export function PostListing() {
       // Create the listing first
       const payload = {
         ...formData,
+        broker_fee: false,
         neighborhood,
         user_id: user.id,
         is_active: false,

--- a/src/services/listings.ts
+++ b/src/services/listings.ts
@@ -179,6 +179,13 @@ export const listingsService = {
   },
 
   async createListing(payload: ListingCreateInput) {
+    if (payload.broker_fee === true) {
+      return {
+        data: null,
+        error: { message: "Broker fees are not permitted on HaDirot." },
+      } as any;
+    }
+
     // If trying to feature a listing on creation, check permissions and limits
     if (payload.is_featured) {
       // Get user profile to check permissions
@@ -234,7 +241,7 @@ export const listingsService = {
       payload.contact_name = capitalizeName(payload.contact_name);
     }
 
-    payload.broker_fee = payload.broker_fee ?? false;
+    payload.broker_fee = false;
 
     const data = {
       ...payload,
@@ -253,6 +260,17 @@ export const listingsService = {
   },
 
   async updateListing(id: string, payload: Partial<ListingCreateInput>) {
+    if (payload.broker_fee === true) {
+      return {
+        data: null,
+        error: { message: "Broker fees are not permitted on HaDirot." },
+      } as any;
+    }
+
+    if (payload.broker_fee !== undefined) {
+      payload.broker_fee = false;
+    }
+
     console.log('[WEB] updateListing called', { id, updates: payload });
     // Get the current listing to check for approval status change
     const { data: currentListing } = await supabase


### PR DESCRIPTION
## Summary
- Prevent broker fee option from staying on by resetting the checkbox and alerting users on submit and toggle.
- Guard listing creation/update APIs against broker_fee=true and always force broker_fee to false.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3063324ac8329a712619aec288df3