### PR TITLE
Restore dashboard functionality and gate agency link

### DIFF
--- a/src/components/shared/Layout.tsx
+++ b/src/components/shared/Layout.tsx
@@ -15,10 +15,12 @@ import {
   BarChart3,
   Menu,
   X,
+  Building2,
 } from "lucide-react";
 import { useAuth, AUTH_CONTEXT_ID } from "@/hooks/useAuth";
 import { usePageTracking } from "../../hooks/usePageTracking";
 import { useAnalyticsAuth } from "../../lib/analytics";
+import { agencyNameToSlug } from "../../utils/agency";
 import { Footer } from "./Footer";
 import { capitalizeName } from "../../utils/formatters";
 
@@ -94,6 +96,16 @@ export function Layout({ children }: LayoutProps) {
       console.log("[Layout] auth", payload);
     }
   }, [loading, user, profile, authContextId]);
+
+  const agencyName =
+    typeof profile?.agency === "string" ? profile.agency.trim() : "";
+  const canAccessAgencyPage =
+    profile?.role === "agent" &&
+    agencyName.length > 0 &&
+    profile?.can_manage_agency === true;
+  const agencySlug = canAccessAgencyPage
+    ? agencyNameToSlug(agencyName)
+    : null;
 
   const handleSignOut = async () => {
     try {
@@ -188,6 +200,16 @@ export function Layout({ children }: LayoutProps) {
                           <LayoutDashboard className="w-4 h-4 mr-2" />
                           My Dashboard
                         </Link>
+                        {canAccessAgencyPage && agencySlug && (
+                          <Link
+                            to={`/agencies/${agencySlug}`}
+                            className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                            onClick={() => setShowUserMenu(false)}
+                          >
+                            <Building2 className="w-4 h-4 mr-2" />
+                            My Agency Page
+                          </Link>
+                        )}
                         <Link
                           to="/favorites"
                           className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
@@ -369,10 +391,9 @@ export function Layout({ children }: LayoutProps) {
                         Account Settings
                       </Link>
                       
-                      {/* My Agency Page - only for agents with agency */}
-                      {profile?.role === 'agent' && profile?.agency && (
+                      {canAccessAgencyPage && agencySlug && (
                         <Link
-                          to={`/agencies/${agencyNameToSlug(profile.agency)}`}
+                          to={`/agencies/${agencySlug}`}
                           onClick={() => setIsMobileMenuOpen(false)}
                           className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
                         >

--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -23,6 +23,7 @@ export interface Profile {
   is_admin: boolean;
   is_banned?: boolean;
   can_feature_listings?: boolean;
+  can_manage_agency?: boolean;
   max_featured_listings_per_user?: number;
   is_banned?: boolean;
   max_featured_listings_per_user?: number;

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -45,7 +45,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const { data, error } = await supabase
         .from("profiles")
         .select(
-          "id, full_name, role, phone, agency, email, is_admin, can_feature_listings, max_featured_listings_per_user, is_banned, created_at, updated_at",
+          "id, full_name, role, phone, agency, email, is_admin, can_feature_listings, max_featured_listings_per_user, can_manage_agency, is_banned, created_at, updated_at",
         )
         .eq("id", session.user.id)
         .maybeSingle();

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,519 +1,615 @@
 import React, { useState, useEffect } from "react";
-import { Link, useNavigate, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 import {
-  Home,
-  Search,
-  Plus,
-  User,
-  Heart,
-  LogOut,
-  Settings,
-  LayoutDashboard,
-  FileText,
-  Edit3,
+  Edit,
+  Eye,
   Star,
-  BarChart3,
-  Menu,
-  X,
+  Trash2,
+  RefreshCw,
+  Plus,
+  EyeOff,
+  AlertTriangle,
 } from "lucide-react";
-import { useAuth, AUTH_CONTEXT_ID } from "@/hooks/useAuth";
-import { usePageTracking } from "../../hooks/usePageTracking";
-import { useAnalyticsAuth } from "@/lib/analytics";
-import { Footer } from "./Footer";
-import { capitalizeName } from "../../utils/formatters";
+import { useAuth } from "@/hooks/useAuth";
+import { Listing } from "../config/supabase";
+import { listingsService } from "../services/listings";
+import { profilesService } from "../services/profiles";
+import { emailService } from "../services/email";
 
-interface LayoutProps {
-  children: React.ReactNode;
-}
-
-export function Layout({ children }: LayoutProps) {
-  const { user, profile, signOut, loading, authContextId } = useAuth();
-  
-  // Initialize analytics tracking
-  usePageTracking();
-  useAnalyticsAuth();
-  
-  const navigate = useNavigate();
-  const location = useLocation();
-  const [showUserMenu, setShowUserMenu] = useState(false);
-  const [showSignOutMessage, setShowSignOutMessage] = useState(false);
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const userMenuRef = React.useRef<HTMLDivElement>(null);
-  const prevUserRef = React.useRef<typeof user>(null);
-  const prevPathnameRef = React.useRef<string>(location.pathname);
-
-  // Close dropdown menu when user logs in
-  useEffect(() => {
-    // If user was null (logged out) and now has a value (logged in)
-    if (prevUserRef.current === null && user !== null) {
-      setShowUserMenu(false);
-    }
-    prevUserRef.current = user;
-  }, [user]);
-
-  // Close dropdown menu on navigation
-  useEffect(() => {
-    if (location.pathname !== prevPathnameRef.current) {
-      setShowUserMenu(false);
-      setIsMobileMenuOpen(false);
-      prevPathnameRef.current = location.pathname;
-    }
-  }, [location.pathname]);
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        userMenuRef.current &&
-        !userMenuRef.current.contains(event.target as Node)
-      ) {
-        setShowUserMenu(false);
-      }
-    };
-
-    if (showUserMenu) {
-      document.addEventListener("mousedown", handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [showUserMenu]);
+export default function Dashboard() {
+  const { user, profile, loading: authLoading, refreshProfile } = useAuth();
+  const [listings, setListings] = useState<Listing[]>([]);
+  const [adminSettings, setAdminSettings] = useState<{
+    max_featured_listings: number;
+    max_featured_per_user: number;
+  } | null>(null);
+  const [globalFeaturedCount, setGlobalFeaturedCount] = useState<number>(0);
+  const [currentUserProfile, setCurrentUserProfile] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
 
   useEffect(() => {
-    const payload = {
-      loading,
-      userPresent: !!user,
-      profilePresent: profile !== undefined,
-      isAdmin: !!profile?.is_admin,
-      authContextId,
-    };
-    if (authContextId !== AUTH_CONTEXT_ID) {
-      console.warn("[Layout] auth context mismatch", payload);
-    } else {
-      console.log("[Layout] auth", payload);
+    if (user && !authLoading) {
+      loadUserListings();
+      loadAdminSettings();
+      loadCurrentUserProfile();
+      loadGlobalFeaturedCount();
     }
-  }, [loading, user, profile, authContextId]);
+  }, [user, authLoading]);
 
-  const handleSignOut = async () => {
+  const loadAdminSettings = async () => {
     try {
-      await signOut();
-      setIsMobileMenuOpen(false);
-      setShowSignOutMessage(true);
-      setTimeout(() => setShowSignOutMessage(false), 3000);
-      navigate("/");
+      const settings = await listingsService.getAdminSettings();
+      setAdminSettings(settings);
     } catch (error) {
-      console.error("Error signing out:", error);
+      console.error("Error loading admin settings:", error);
     }
   };
 
-  const Logo = () => (
-    <div className="font-brand uppercase tracking-wide text-xl md:text-2xl">
-      HADIROT
-    </div>
-  );
+  const loadGlobalFeaturedCount = async () => {
+    try {
+      const count = await listingsService.getGlobalFeaturedCount();
+      setGlobalFeaturedCount(count);
+    } catch (error) {
+      console.error("Error loading global featured count:", error);
+    }
+  };
+
+  const loadCurrentUserProfile = async () => {
+    if (!user) return;
+
+    try {
+      const profileData = await profilesService.getProfile(user.id);
+      setCurrentUserProfile(profileData);
+    } catch (error) {
+      console.error("Error loading current user profile:", error);
+    }
+  };
+
+  const loadUserListings = async () => {
+    if (!user) return;
+
+    try {
+      const data = await listingsService.getUserListings(user.id);
+      setListings(data);
+    } catch (error) {
+      console.error("Error loading user listings:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleToggleFeature = async (
+    listingId: string,
+    isFeatured: boolean,
+  ) => {
+    setActionLoading(listingId);
+    try {
+      const updates: any = { is_featured: !isFeatured };
+
+      // The service layer will handle setting featured_expires_at automatically
+
+      await listingsService.updateListing(listingId, updates);
+
+      // Send email notification for featured status change
+      try {
+        if (user?.email && profile?.full_name) {
+          const listing = listings.find((l) => l.id === listingId);
+          if (listing) {
+            await emailService.sendListingFeaturedEmail(
+              user.email,
+              profile.full_name,
+              listing.title,
+              !isFeatured, // New featured status (opposite of current)
+            );
+            console.log("✅ Email sent: featured status change to", user.email);
+          }
+        }
+      } catch (emailError) {
+        console.error(
+          "❌ Email failed: featured status change -",
+          emailError.message,
+        );
+        // Don't block the user flow if email fails
+      }
+
+      await loadUserListings();
+      // Refresh user profile to get updated permissions and limits
+      await refreshProfile();
+    } catch (error) {
+      console.error("Error toggling featured status:", error);
+
+      // Show specific error messages based on the error
+      let errorMessage = "Failed to update listing. Please try again.";
+      if (error instanceof Error) {
+        if (error.message.includes("permission")) {
+          errorMessage =
+            "You do not have permission to feature listings. Please contact support to upgrade your account.";
+        } else if (
+          error.message.includes("sitewide maximum") ||
+          error.message.includes("platform only allows")
+        ) {
+          errorMessage =
+            "The website limit for featured listings has been reached. Please try again later.";
+        } else if (error.message.includes("You can only feature")) {
+          errorMessage = error.message;
+        }
+      }
+
+      alert(errorMessage);
+    } finally {
+      setActionLoading(null);
+      // Refresh global state to update UI limits
+      await loadAdminSettings();
+      await loadGlobalFeaturedCount();
+    }
+  };
+
+  const handleRenewListing = async (listingId: string) => {
+    setActionLoading(listingId);
+    try {
+      await listingsService.updateListing(listingId, {
+        last_published_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        is_active: true,
+      });
+
+      // Send email notification for listing reactivation
+      try {
+        if (user?.email && profile?.full_name) {
+          const listing = listings.find((l) => l.id === listingId);
+          if (listing) {
+            await emailService.sendListingReactivationEmail(
+              user.email,
+              profile.full_name,
+              listing.title,
+            );
+            console.log("✅ Email sent: listing reactivation to", user.email);
+          }
+        }
+      } catch (emailError) {
+        console.error(
+          "❌ Email failed: listing reactivation -",
+          emailError.message,
+        );
+        // Don't block the user flow if email fails
+      }
+
+      await loadUserListings();
+    } catch (error) {
+      console.error("Error renewing listing:", error);
+      alert("Failed to renew listing. Please try again.");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleUnpublishListing = async (listingId: string) => {
+    if (
+      !confirm(
+        "Are you sure you want to unpublish this listing? It will be hidden from public view but can be republished later.",
+      )
+    ) {
+      return;
+    }
+
+    setActionLoading(listingId);
+    try {
+      await listingsService.updateListing(listingId, {
+        is_active: false,
+        updated_at: new Date().toISOString(),
+      });
+      await loadUserListings();
+
+      // Send email notification
+      try {
+        if (user?.email && profile?.full_name) {
+          const listing = listings.find((l) => l.id === listingId);
+          if (listing) {
+            await emailService.sendListingDeactivationEmail(
+              user.email,
+              profile.full_name,
+              listing.title,
+            );
+            console.log("✅ Email sent: listing deactivation to", user.email);
+          }
+        }
+      } catch (emailError) {
+        console.error(
+          "❌ Email failed: listing deactivation -",
+          emailError.message,
+        );
+        // Don't block the user flow if email fails
+      }
+    } catch (error) {
+      console.error("Error unpublishing listing:", error);
+      alert("Failed to unpublish listing. Please try again.");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+  const handleDeleteListing = async (listingId: string) => {
+    if (
+      !confirm(
+        "Are you sure you want to permanently delete this listing? This action cannot be undone.",
+      )
+    ) {
+      return;
+    }
+
+    // Store listing data before deletion for email
+    const listingToDelete = listings.find((l) => l.id === listingId);
+
+    setActionLoading(listingId);
+    try {
+      await listingsService.deleteListing(listingId);
+      // Remove from UI immediately on success
+      setListings((prev) => prev.filter((listing) => listing.id !== listingId));
+
+      // Send email notification
+      try {
+        if (user?.email && profile?.full_name && listingToDelete) {
+          await emailService.sendListingDeletedEmail(
+            user.email,
+            profile.full_name,
+            listingToDelete.title,
+          );
+          console.log("✅ Email sent: listing deletion to", user.email);
+        }
+      } catch (emailError) {
+        console.error(
+          "❌ Email failed: listing deletion -",
+          emailError.message,
+        );
+        // Don't block the user flow if email fails
+      }
+
+      console.log("✅ Listing deleted successfully");
+    } catch (error) {
+      console.error("❌ Error deleting listing:", error);
+      alert("Failed to delete listing. Please try again.");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const formatPrice = (price: number | null) => {
+    if (price == null) return "";
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(price);
+  };
+
+  // Calculate user's effective featured limit and current count
+  const effectiveUserFeaturedLimit = (currentUserProfile || profile)?.is_admin
+    ? Infinity
+    : ((currentUserProfile || profile)?.max_featured_listings_per_user ??
+      adminSettings?.max_featured_per_user ??
+      0);
+
+  const currentUserFeaturedCount = listings.filter(
+    (listing) =>
+      listing.is_featured &&
+      (!listing.featured_expires_at ||
+        new Date(listing.featured_expires_at) > new Date()),
+  ).length;
+
+  const globalLimitReached = adminSettings
+    ? globalFeaturedCount >= adminSettings.max_featured_listings
+    : false;
+  const canFeatureMore =
+    (currentUserProfile || profile)?.is_admin ||
+    currentUserFeaturedCount < effectiveUserFeaturedLimit;
+
+  // Helper function to check if a listing is actually featured (not expired)
+  const isListingCurrentlyFeatured = (listing: Listing) => {
+    return (
+      listing.is_featured &&
+      listing.featured_expires_at &&
+      new Date(listing.featured_expires_at) > new Date()
+    );
+  };
+  if (authLoading) {
+    return (
+      <div className="max-w-6xl mx-auto px-4 py-10 text-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#4E4B43] mx-auto"></div>
+        <p className="text-gray-600 mt-4">Loading...</p>
+      </div>
+    );
+  }
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <header className="sticky top-0 z-50 bg-brand-800 text-white border-b border-black/5 shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 md:px-6 h-14 md:h-16 flex items-center justify-between">
-          {/* Left spacer for balance */}
-          <div className="flex-1"></div>
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+      {/* Banned User Warning Banner */}
+      {(currentUserProfile || profile)?.is_banned && (
+        <div className="mb-6 bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="flex items-center">
+            <AlertTriangle className="w-5 h-5 text-red-600 mr-3 flex-shrink-0" />
+            <div className="text-red-800">
+              <p className="font-medium">
+                🚫 Your account has been banned. Your listings are hidden from
+                public view.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
 
-          {/* Centered Logo */}
-          <Link to="/" className="flex-shrink-0">
-            <Logo />
+      <h1 className="text-3xl font-bold text-[#273140] mb-4">
+        Welcome back
+        {(currentUserProfile || profile)?.full_name
+          ? `, ${(currentUserProfile || profile).full_name}`
+          : ""}
+        !
+      </h1>
+
+      <div>
+        <div className="flex items-center justify-between mb-6">
+          <p className="text-gray-600">Manage your property listings</p>
+          <Link
+            to="/post"
+            className="bg-accent-500 text-white px-4 py-2 rounded-md font-medium hover:bg-accent-600 transition-colors flex items-center"
+          >
+            <Plus className="w-4 h-4 mr-2" />
+            Add New Listing
           </Link>
-
-          {/* Right side navigation */}
-          <div className="flex-1 flex justify-end">
-            <nav className="hidden md:flex items-center space-x-4">
-              <Link
-                to="/browse"
-                className={`flex items-center px-3 py-2 text-sm font-medium rounded-md transition-opacity text-white hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/40 ${
-                  location.pathname === "/browse" ? "opacity-90" : ""
-                }`}
-              >
-                <Search className="w-4 h-4 mr-2" />
-                Browse
-              </Link>
-              <Link
-                to="/post"
-                className={`flex items-center px-3 py-2 text-sm font-medium rounded-md transition-opacity text-white hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/40 ${
-                  location.pathname === "/post" ? "opacity-90" : ""
-                }`}
-              >
-                <Plus className="w-4 h-4 mr-2" />
-                Post
-              </Link>
-            </nav>
-
-            <div className="hidden md:flex items-center ml-4">
-              {user ? (
-                <div className="relative" ref={userMenuRef}>
-                  <button
-                    onClick={() => setShowUserMenu(!showUserMenu)}
-                    className="flex items-center space-x-2 text-white hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-white/40"
-                  >
-                    <User className="w-5 h-5" />
-                    <span className="hidden sm:inline text-sm font-medium">
-                      {profile?.full_name
-                        ? capitalizeName(profile.full_name)
-                        : ""}
-                    </span>
-                  </button>
-
-                  {showUserMenu && (
-                    <div className="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg border border-gray-200 z-50">
-                      <div className="py-1">
-                        <div className="px-4 py-2 text-sm text-gray-500 border-b">
-                          {profile?.role === "agent" && profile?.agency && (
-                            <span className="block">{profile.agency}</span>
-                          )}
-                          <span className="capitalize">{profile?.role}</span>
-                        </div>
-                        <Link
-                          to="/account-settings"
-                          className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                          onClick={() => setShowUserMenu(false)}
-                        >
-                          <User className="w-4 h-4 mr-2" />
-                          Account
-                        </Link>
-                        <Link
-                          to="/dashboard"
-                          className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                          onClick={() => setShowUserMenu(false)}
-                        >
-                          <LayoutDashboard className="w-4 h-4 mr-2" />
-                          My Dashboard
-                        </Link>
-                        <Link
-                          to="/favorites"
-                          className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                          onClick={() => setShowUserMenu(false)}
-                        >
-                          <Heart className="w-4 h-4 mr-2" />
-                          My Favorites
-                        </Link>
-                        {/* Debug log to check profile and loading state */}
-
-                        {!loading && profile?.is_admin && (
-                          <>
-                            <Link
-                              to="/admin"
-                              className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                              onClick={() => setShowUserMenu(false)}
-                            >
-                              <Settings className="w-4 h-4 mr-2" />
-                              Admin Panel
-                            </Link>
-                            <Link
-                              to="/admin/static-pages"
-                              className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                              onClick={() => setShowUserMenu(false)}
-                            >
-                              <FileText className="w-4 h-4 mr-2" />
-                              Static Pages
-                            </Link>
-                            <Link
-                              to="/admin/footer"
-                              className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                              onClick={() => setShowUserMenu(false)}
-                            >
-                              <Edit3 className="w-4 h-4 mr-2" />
-                              Footer Editor
-                            </Link>
-                            <Link
-                              to="/admin/featured-settings"
-                              className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                              onClick={() => setShowUserMenu(false)}
-                            >
-                              <Star className="w-4 h-4 mr-2" />
-                              Featured Settings
-                            </Link>
-                            <Link
-                              to="/internal-analytics"
-                              className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                              onClick={() => setShowUserMenu(false)}
-                            >
-                              <BarChart3 className="w-4 h-4 mr-2" />
-                              Analytics
-                            </Link>
-                          </>
-                        )}
-                        <button
-                          onClick={handleSignOut}
-                          className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 text-left"
-                        >
-                          <LogOut className="w-4 h-4 mr-2" />
-                          Sign Out
-                        </button>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <Link
-                  to="/auth"
-                  className="bg-brand-700 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-brand-800 transition-colors"
-                >
-                  Sign In
-                </Link>
-              )}
-            </div>
-
-            {/* Mobile menu button */}
-            <div className="md:hidden flex items-center">
-              <button
-                onClick={() => setIsMobileMenuOpen(true)}
-                className="p-2 text-white hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-white/40"
-              >
-                <Menu className="w-6 h-6" />
-              </button>
-            </div>
-          </div>
         </div>
-      </header>
 
-      {/* Mobile Sidebar */}
-      {isMobileMenuOpen && (
-        <>
-          {/* Overlay */}
-          <div
-            className="fixed inset-0 bg-black bg-opacity-50 z-40 md:hidden"
-            onClick={() => setIsMobileMenuOpen(false)}
-          />
-
-          {/* Sidebar */}
-          <div className="fixed top-0 right-0 h-full w-80 bg-white shadow-xl z-50 md:hidden transform transition-transform duration-300 ease-in-out">
-            <div className="flex flex-col h-full">
-              {/* Header */}
-              <div className="flex items-center justify-between p-4 border-b border-gray-200">
-                <div className="flex items-center">
-                  <div className="text-brand-700">
-                    <Logo />
-                  </div>
-                </div>
-                <button
-                  onClick={() => setIsMobileMenuOpen(false)}
-                  className="text-gray-400 hover:text-gray-600 transition-colors p-1"
-                >
-                  <X className="w-6 h-6" />
-                </button>
-              </div>
-
-              {/* Navigation */}
-              <div className="flex-1 overflow-y-auto">
-                <nav className="p-4 space-y-2">
-                  <Link
-                    to="/"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                    className={`flex items-center px-4 py-3 text-base font-medium rounded-md transition-colors ${
-                      location.pathname === "/"
-                        ? "text-brand-700 bg-gray-100"
-                        : "text-gray-600 hover:text-brand-700 hover:bg-gray-50"
-                    }`}
-                  >
-                    <Home className="w-5 h-5 mr-3" />
-                    Home
-                  </Link>
-                  <Link
-                    to="/browse"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                    className={`flex items-center px-4 py-3 text-base font-medium rounded-md transition-colors ${
-                      location.pathname === "/browse"
-                        ? "text-brand-700 bg-gray-100"
-                        : "text-gray-600 hover:text-brand-700 hover:bg-gray-50"
-                    }`}
-                  >
-                    <Search className="w-5 h-5 mr-3" />
-                    Browse Listings
-                  </Link>
-                  <Link
-                    to="/post"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                    className={`flex items-center px-4 py-3 text-base font-medium rounded-md transition-colors ${
-                      location.pathname === "/post"
-                        ? "text-brand-700 bg-gray-100"
-                        : "text-gray-600 hover:text-brand-700 hover:bg-gray-50"
-                    }`}
-                  >
-                    <Plus className="w-5 h-5 mr-3" />
-                    Post Listing
-                  </Link>
-
-                  {user && (
-                    <>
-                      <div className="border-t border-gray-200 my-4"></div>
-                      <div className="px-4 py-2">
-                        <div className="text-sm font-medium text-gray-900">
-                          {profile?.full_name
-                            ? capitalizeName(profile.full_name)
-                            : ""}
-                        </div>
-                        <div className="text-sm text-gray-500">
-                          {profile?.role === "agent" && profile?.agency && (
-                            <span className="block">{profile.agency}</span>
-                          )}
-                          <span className="capitalize">{profile?.role}</span>
-                        </div>
-                      </div>
-
-                      <Link
-                        to="/account-settings"
-                        onClick={() => setIsMobileMenuOpen(false)}
-                        className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                      >
-                        <User className="w-5 h-5 mr-3" />
-                        Account Settings
-                      </Link>
-                      
-                      {/* My Agency Page - only for agents with agency */}
-                      {profile?.role === 'agent' && profile?.agency && (
-                        <Link
-                          to={`/agencies/${agencyNameToSlug(profile.agency)}`}
-                          onClick={() => setIsMobileMenuOpen(false)}
-                          className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                        >
-                          <Building2 className="w-5 h-5 mr-3" />
-                          My Agency Page
-                        </Link>
-                      )}
-                      
-                      <Link
-                        to="/dashboard"
-                        onClick={() => setIsMobileMenuOpen(false)}
-                        className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                      >
-                        <LayoutDashboard className="w-5 h-5 mr-3" />
-                        My Dashboard
-                      </Link>
-                      <Link
-                        to="/favorites"
-                        onClick={() => setIsMobileMenuOpen(false)}
-                        className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                      >
-                        <Heart className="w-5 h-5 mr-3" />
-                        My Favorites
-                      </Link>
-
-                      {!loading && profile?.is_admin && (
-                        <>
-                          <div className="border-t border-gray-200 my-4"></div>
-                          <div className="px-4 py-2">
-                            <div className="text-sm font-medium text-gray-500 uppercase tracking-wider">
-                              Admin
-                            </div>
-                          </div>
-                          <Link
-                            to="/admin"
-                            onClick={() => setIsMobileMenuOpen(false)}
-                            className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                          >
-                            <Settings className="w-5 h-5 mr-3" />
-                            Admin Panel
-                          </Link>
-                          <Link
-                            to="/admin/static-pages"
-                            onClick={() => setIsMobileMenuOpen(false)}
-                            className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                          >
-                            <FileText className="w-5 h-5 mr-3" />
-                            Static Pages
-                          </Link>
-                          <Link
-                            to="/admin/footer"
-                            onClick={() => setIsMobileMenuOpen(false)}
-                            className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                          >
-                            <Edit3 className="w-5 h-5 mr-3" />
-                            Footer Editor
-                          </Link>
-                          <Link
-                            to="/admin/featured-settings"
-                            onClick={() => setIsMobileMenuOpen(false)}
-                            className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                          >
-                            <Star className="w-5 h-5 mr-3" />
-                            Featured Settings
-                          </Link>
-                          <Link
-                            to="/internal-analytics"
-                            onClick={() => setIsMobileMenuOpen(false)}
-                            className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                          >
-                            <BarChart3 className="w-5 h-5 mr-3" />
-                            Analytics
-                          </Link>
-                          <Link
-                            to="/internal-analytics"
-                            onClick={() => setIsMobileMenuOpen(false)}
-                            className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                          >
-                            <BarChart3 className="w-5 h-5 mr-3" />
-                            Analytics
-                          </Link>
-                        </>
-                      )}
-
-                      <div className="border-t border-gray-200 my-4"></div>
-                      <button
-                        onClick={handleSignOut}
-                        className="flex items-center w-full px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors text-left"
-                      >
-                        <LogOut className="w-5 h-5 mr-3" />
-                        Sign Out
-                      </button>
-                    </>
-                  )}
-
-                  {!user && (
-                    <>
-                      <div className="border-t border-gray-200 my-4"></div>
-                      <Link
-                        to="/auth"
-                        onClick={() => setIsMobileMenuOpen(false)}
-                        className="flex items-center px-4 py-3 text-base font-medium bg-[#273140] text-white rounded-md hover:bg-[#1e252f] transition-colors"
-                      >
-                        <User className="w-5 h-5 mr-3" />
-                        Sign In
-                      </Link>
-                    </>
-                  )}
-                </nav>
-              </div>
-            </div>
-          </div>
-        </>
-      )}
-
-      {/* Sign Out Success Message */}
-      {showSignOutMessage && (
-        <div className="fixed top-20 right-4 bg-green-500 text-white px-4 py-2 rounded-md shadow-lg z-50 animate-fade-in">
-          Successfully signed out!
-        </div>
-      )}
-
-      <main className="flex-1">
         {loading ? (
-          <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-            <div className="text-center">
-              <div className="flex items-center justify-center mb-4">
-                <div className="text-brand-700">
-                  <Logo />
-                </div>
-              </div>
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-brand-700 mx-auto"></div>
-              <p className="text-gray-600 mt-4">Loading...</p>
+          <div className="text-center py-8">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#273140] mx-auto"></div>
+            <p className="text-gray-600 mt-4">Loading your listings...</p>
+          </div>
+        ) : listings.length === 0 ? (
+          <div className="text-center py-12 bg-white rounded-lg shadow-sm border border-gray-200">
+            <div className="text-gray-400 mb-4">
+              <svg
+                className="mx-auto h-12 w-12"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+                />
+              </svg>
             </div>
+            <h3 className="text-lg font-medium text-gray-900 mb-2">
+              No listings yet
+            </h3>
+            <p className="text-gray-500 mb-4">
+              Start by creating your first property listing.
+            </p>
+            <Link
+              to="/post"
+              className="inline-flex items-center bg-accent-500 text-white px-4 py-2 rounded-md font-medium hover:bg-accent-600 transition-colors"
+            >
+              <Plus className="w-4 h-4 mr-2" />
+              Create Listing
+            </Link>
           </div>
         ) : (
-          children
-        )}
-      </main>
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+            <div className="overflow-x-auto min-w-full">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider min-w-0 w-1/4">
+                      Property
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-24">
+                      Price
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-20">
+                      Views
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-32">
+                      Status
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-40">
+                      Created
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-48">
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {listings.map((listing) => {
+                    const featuredImage =
+                      listing.listing_images?.find((img) => img.is_featured) ||
+                      listing.listing_images?.[0];
 
-      <Footer />
+                    return (
+                      <tr key={listing.id} className="hover:bg-gray-50">
+                        <td className="px-6 py-4">
+                          <div className="flex items-center">
+                            {featuredImage && (
+                              <img
+                                src={featuredImage.image_url}
+                                alt={listing.title}
+                                className="w-12 h-12 object-cover rounded-lg mr-4"
+                              />
+                            )}
+                            <div className="min-w-0 flex-1">
+                              <Link
+                                to={`/listing/${listing.id}`}
+                                className="font-medium text-gray-900 hover:text-[#4E4B43] transition-colors block truncate"
+                              >
+                                {listing.title}
+                              </Link>
+                              <div className="text-sm text-gray-500 truncate">
+                                {listing.bedrooms} bed, {listing.bathrooms} bath
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                          {listing.call_for_price
+                            ? 'Call for Price'
+                            : `${formatPrice(listing.price)}/month`}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-center">
+                          <div className="flex items-center text-sm text-gray-900">
+                            <Eye className="w-4 h-4 mr-1 text-gray-400" />
+                            {listing.views || 0}
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <div className="flex items-center space-x-2">
+                            <span
+                              className={`px-2 py-1 text-xs rounded-full ${
+                                listing.is_active
+                                  ? "bg-green-100 text-green-800"
+                                  : "bg-red-100 text-red-800"
+                              }`}
+                            >
+                              {listing.is_active ? "Active" : "Inactive"}
+                            </span>
+                            {!listing.approved && (
+                              <span className="px-2 py-1 text-xs bg-yellow-100 text-yellow-800 rounded-full">
+                                Pending Approval
+                              </span>
+                            )}
+                            {isListingCurrentlyFeatured(listing) && (
+                              <span className="px-2 py-1 text-xs bg-accent-500 text-white rounded-full flex items-center">
+                                <Star className="w-3 h-3 mr-1" />
+                                Featured
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                          <div>
+                            <div className="whitespace-nowrap">
+                              Posted:{" "}
+                              {new Date(
+                                listing.created_at,
+                              ).toLocaleDateString()}
+                            </div>
+                            {listing.last_published_at && (
+                              <div className="text-xs text-gray-400 whitespace-nowrap">
+                                Last Published:{" "}
+                                {new Date(
+                                  listing.last_published_at,
+                                ).toLocaleDateString()}
+                              </div>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                          <div className="flex items-center space-x-3">
+                            <Link
+                              to={`/listing/${listing.id}`}
+                              title="View Listing"
+                              className="text-[#273140] hover:text-[#1e252f] transition-colors flex-shrink-0"
+                            >
+                              <Eye className="w-5 h-5" />
+                            </Link>
+
+                            <Link
+                              to={`/edit/${listing.id}`}
+                              className="flex items-center space-x-1 px-2 py-1 text-blue-600 hover:text-blue-800 transition-colors flex-shrink-0"
+                              title="Edit Listing"
+                            >
+                              <Edit className="w-4 h-4" />
+                              <span className="text-sm hidden sm:inline">
+                                Edit
+                              </span>
+                            </Link>
+
+                            <button
+                              type="button"
+                              onClick={() =>
+                                handleToggleFeature(
+                                  listing.id,
+                                  isListingCurrentlyFeatured(listing),
+                                )
+                              }
+                              disabled={
+                                actionLoading === listing.id ||
+                                (!isListingCurrentlyFeatured(listing) &&
+                                  (!canFeatureMore || globalLimitReached))
+                              }
+                              className={`transition-colors flex-shrink-0 ${
+                                isListingCurrentlyFeatured(listing)
+                                  ? "text-accent-600 hover:text-accent-600"
+                                  : !canFeatureMore || globalLimitReached
+                                    ? "text-gray-300 cursor-not-allowed"
+                                    : "text-gray-400 hover:text-accent-600"
+                              }`}
+                              title={
+                                isListingCurrentlyFeatured(listing)
+                                  ? "Remove Featured"
+                                  : globalLimitReached
+                                    ? "The sitewide maximum for featured listings has been reached"
+                                    : !canFeatureMore
+                                      ? `You have reached your featured listing limit (${currentUserFeaturedCount}/${effectiveUserFeaturedLimit})`
+                                      : "Make Featured"
+                              }
+                            >
+                              <Star
+                                className={`w-5 h-5 ${isListingCurrentlyFeatured(listing) ? "fill-current" : ""}`}
+                              />
+                            </button>
+
+                            {listing.is_active ? (
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  handleUnpublishListing(listing.id)
+                                }
+                                disabled={
+                                  actionLoading === listing.id ||
+                                  !listing.approved
+                                }
+                                className="text-orange-600 hover:text-orange-800 transition-colors flex-shrink-0"
+                                title="Unpublish Listing"
+                              >
+                                <EyeOff className="w-5 h-5" />
+                              </button>
+                            ) : (
+                              <button
+                                type="button"
+                                onClick={() => handleRenewListing(listing.id)}
+                                disabled={
+                                  actionLoading === listing.id ||
+                                  !listing.approved
+                                }
+                                className="text-blue-600 hover:text-blue-800 transition-colors flex-shrink-0"
+                                title="Republish Listing"
+                              >
+                                <RefreshCw className="w-5 h-5" />
+                              </button>
+                            )}
+                            <button
+                              type="button"
+                              onClick={() => handleDeleteListing(listing.id)}
+                              disabled={actionLoading === listing.id}
+                              className="text-red-600 hover:text-red-800 transition-colors flex-shrink-0"
+                              title="Delete Listing"
+                            >
+                              <Trash2 className="w-5 h-5" />
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
+
+export { Dashboard };

--- a/src/utils/agency.ts
+++ b/src/utils/agency.ts
@@ -1,0 +1,35 @@
+export function agencyNameToSlug(name: string): string {
+  if (!name) {
+    return '';
+  }
+
+  const normalized = name
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+
+  return normalized
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function slugToAgencyLabel(slug: string): string {
+  if (!slug) {
+    return '';
+  }
+
+  const cleaned = slug
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!cleaned) {
+    return '';
+  }
+
+  return cleaned
+    .split(' ')
+    .map(part => (part ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ');
+}


### PR DESCRIPTION
## Summary
- restore the dashboard page to render the full listing management experience instead of the placeholder export
- gate the "My Agency Page" dropdown link on the can_manage_agency profile flag and fix layout imports to resolve build issues
- expose the can_manage_agency flag through the profile type and auth loader so it is available to the layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8b126f7308329b2bed59ee02c5734