### PR TITLE
Refactor agency page layout and add url normalization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { ListingDetail } from './pages/ListingDetail';
 import { Favorites } from './pages/Favorites';
 import { AdminPanel } from './pages/AdminPanel';
 import { Dashboard } from './pages/Dashboard';
+import { AgencySettings } from './pages/AgencySettings';
 import { StaticPageEditor } from './pages/admin/StaticPageEditor';
 import { FooterEditor } from './pages/admin/FooterEditor';
 import { FeaturedSettingsAdmin } from './pages/admin/FeaturedSettingsAdmin';
@@ -67,6 +68,7 @@ function App() {
                 <Route path="/admin/footer" element={<FooterEditor />} />
                 <Route path="/admin/featured-settings" element={<FeaturedSettingsAdmin />} />
                 <Route path="/dashboard" element={<Dashboard />} />
+                <Route path="/dashboard/agency-settings" element={<AgencySettings />} />
                 <Route path="/account-settings" element={<AccountSettings />} />
                <Route path="/internal-analytics" element={<InternalAnalytics />} />
                 <Route path="/internal-analytics" element={<InternalAnalytics />} />

--- a/src/components/shared/Layout.tsx
+++ b/src/components/shared/Layout.tsx
@@ -15,10 +15,13 @@ import {
   BarChart3,
   Menu,
   X,
+  Building2,
+  Paintbrush,
 } from "lucide-react";
 import { useAuth, AUTH_CONTEXT_ID } from "@/hooks/useAuth";
 import { usePageTracking } from "../../hooks/usePageTracking";
 import { useAnalyticsAuth } from "../../lib/analytics";
+import { agencyNameToSlug } from "../../utils/agency";
 import { Footer } from "./Footer";
 import { capitalizeName } from "../../utils/formatters";
 
@@ -94,6 +97,16 @@ export function Layout({ children }: LayoutProps) {
       console.log("[Layout] auth", payload);
     }
   }, [loading, user, profile, authContextId]);
+
+  const agencyName =
+    typeof profile?.agency === "string" ? profile.agency.trim() : "";
+  const canAccessAgencyPage =
+    profile?.role === "agent" &&
+    agencyName.length > 0 &&
+    profile?.can_manage_agency === true;
+  const agencySlug = canAccessAgencyPage
+    ? agencyNameToSlug(agencyName)
+    : null;
 
   const handleSignOut = async () => {
     try {
@@ -188,6 +201,26 @@ export function Layout({ children }: LayoutProps) {
                           <LayoutDashboard className="w-4 h-4 mr-2" />
                           My Dashboard
                         </Link>
+                        {canAccessAgencyPage && agencySlug && (
+                          <Link
+                            to={`/agencies/${agencySlug}`}
+                            className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                            onClick={() => setShowUserMenu(false)}
+                          >
+                            <Building2 className="w-4 h-4 mr-2" />
+                            My Agency Page
+                          </Link>
+                        )}
+                        {canAccessAgencyPage && (
+                          <Link
+                            to="/dashboard/agency-settings"
+                            className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                            onClick={() => setShowUserMenu(false)}
+                          >
+                            <Paintbrush className="w-4 h-4 mr-2" />
+                            Agency Settings
+                          </Link>
+                        )}
                         <Link
                           to="/favorites"
                           className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
@@ -369,10 +402,9 @@ export function Layout({ children }: LayoutProps) {
                         Account Settings
                       </Link>
                       
-                      {/* My Agency Page - only for agents with agency */}
-                      {profile?.role === 'agent' && profile?.agency && (
+                      {canAccessAgencyPage && agencySlug && (
                         <Link
-                          to={`/agencies/${agencyNameToSlug(profile.agency)}`}
+                          to={`/agencies/${agencySlug}`}
                           onClick={() => setIsMobileMenuOpen(false)}
                           className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
                         >
@@ -380,7 +412,17 @@ export function Layout({ children }: LayoutProps) {
                           My Agency Page
                         </Link>
                       )}
-                      
+                      {canAccessAgencyPage && (
+                        <Link
+                          to="/dashboard/agency-settings"
+                          onClick={() => setIsMobileMenuOpen(false)}
+                          className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
+                        >
+                          <Paintbrush className="w-5 h-5 mr-3" />
+                          Agency Settings
+                        </Link>
+                      )}
+
                       <Link
                         to="/dashboard"
                         onClick={() => setIsMobileMenuOpen(false)}

--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -19,12 +19,12 @@ export interface Profile {
   full_name: string;
   role: UserRole;
   phone?: string;
+  email?: string;
   agency?: string;
   is_admin: boolean;
   is_banned?: boolean;
   can_feature_listings?: boolean;
-  max_featured_listings_per_user?: number;
-  is_banned?: boolean;
+  can_manage_agency?: boolean;
   max_featured_listings_per_user?: number;
   created_at: string;
   updated_at: string;
@@ -111,4 +111,18 @@ export interface FooterRichTextData {
 export interface FooterLinkData {
   text: string;
   url: string;
+}
+
+export interface Agency {
+  id: string;
+  name: string;
+  slug: string;
+  logo_url?: string | null;
+  banner_url?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  website?: string | null;
+  about_html?: string | null;
+  created_at: string;
+  updated_at: string;
 }

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -45,7 +45,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const { data, error } = await supabase
         .from("profiles")
         .select(
-          "id, full_name, role, phone, agency, email, is_admin, can_feature_listings, max_featured_listings_per_user, is_banned, created_at, updated_at",
+          "id, full_name, role, phone, agency, email, is_admin, can_feature_listings, max_featured_listings_per_user, can_manage_agency, is_banned, created_at, updated_at",
         )
         .eq("id", session.user.id)
         .maybeSingle();

--- a/src/pages/AgencyPage.tsx
+++ b/src/pages/AgencyPage.tsx
@@ -1,12 +1,24 @@
-import React, { useState, useEffect } from "react";
-import { useParams, useSearchParams, Link } from "react-router-dom";
-import { Share2, Filter, X, ChevronLeft, ChevronRight } from "lucide-react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
+import {
+  Share2,
+  Filter,
+  X,
+  ChevronLeft,
+  ChevronRight,
+  Phone,
+  Mail,
+  Globe,
+} from "lucide-react";
 import { ListingCard } from "../components/listings/ListingCard";
-import { Listing, supabase } from "../config/supabase";
-import { listingsService } from "../services/listings";
+import { Listing, Agency } from "@/config/supabase";
+import { listingsService } from "@/services/listings";
+import { agenciesService } from "@/services/agencies";
+import { slugToAgencyLabel } from "@/utils/agency";
+import { normalizeUrlForHref } from "@/utils/url";
 import { useAuth } from "@/hooks/useAuth";
-import { track } from "../lib/analytics";
-import { useListingImpressions } from "../hooks/useListingImpressions";
+import { track } from "@/lib/analytics";
+import { useListingImpressions } from "@/hooks/useListingImpressions";
 
 interface AgencyFilters {
   bedrooms?: number;
@@ -15,35 +27,21 @@ interface AgencyFilters {
   sort?: 'newest' | 'price_asc' | 'price_desc';
 }
 
-// Convert agency name to URL slug
-function agencyNameToSlug(agencyName: string): string {
-  return agencyName
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
-
-// Convert URL slug back to potential agency name patterns for matching
-function slugToAgencyPatterns(slug: string): string[] {
-  // Generate multiple potential matches for the agency name
-  const basePattern = slug.replace(/-/g, ' ');
-  const patterns = [
-    basePattern,
-    basePattern.replace(/\b\w/g, l => l.toUpperCase()), // Title Case
-    basePattern.toUpperCase(),
-    slug.replace(/-/g, ''), // No spaces
-    slug.replace(/-/g, '_'), // Underscores
-  ];
-  
-  return [...new Set(patterns)]; // Remove duplicates
-}
-
 export function AgencyPage() {
   const { slug } = useParams<{ slug: string }>();
+  const slugParam = slug ?? "";
+  const derivedAgencyLabel = slugToAgencyLabel(slugParam);
   const [searchParams, setSearchParams] = useSearchParams();
   const { user } = useAuth();
-  
-  const [agencyName, setAgencyName] = useState<string>("");
+
+  const [agencyDisplayName, setAgencyDisplayName] = useState<string>(
+    derivedAgencyLabel,
+  );
+  const [agencyDetails, setAgencyDetails] = useState<Agency | null>(null);
+  const [agencyDetailsLoaded, setAgencyDetailsLoaded] = useState(false);
+  const [matchedAgencyName, setMatchedAgencyName] = useState<string | null>(null);
+  const [profilesLoaded, setProfilesLoaded] = useState(false);
+  const agencyDetailsRef = useRef<Agency | null>(null);
   const [listings, setListings] = useState<Listing[]>([]);
   const [userFavorites, setUserFavorites] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
@@ -51,6 +49,96 @@ export function AgencyPage() {
   const [currentPage, setCurrentPage] = useState(1);
   const [showFiltersMobile, setShowFiltersMobile] = useState(false);
   const [filters, setFilters] = useState<AgencyFilters>({});
+  const [shareToastMessage, setShareToastMessage] = useState<string | null>(null);
+  const shareToastTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resolvedAgencyDisplayName =
+    agencyDetails?.name?.trim() ||
+    agencyDisplayName ||
+    derivedAgencyLabel ||
+    (slugParam ? slugParam : "Agency");
+  const agencyExists = useMemo<boolean | null>(() => {
+    if (!slugParam) {
+      return null;
+    }
+
+    if (matchedAgencyName || agencyDetails) {
+      return true;
+    }
+
+    if (profilesLoaded && agencyDetailsLoaded) {
+      return false;
+    }
+
+    return null;
+  }, [
+    slugParam,
+    matchedAgencyName,
+    agencyDetails,
+    profilesLoaded,
+    agencyDetailsLoaded,
+  ]);
+
+  useEffect(() => {
+    setAgencyDisplayName(derivedAgencyLabel);
+    setMatchedAgencyName(null);
+    setProfilesLoaded(false);
+    setAgencyDetails(null);
+    setAgencyDetailsLoaded(false);
+    agencyDetailsRef.current = null;
+  }, [derivedAgencyLabel]);
+
+  useEffect(() => {
+    return () => {
+      if (shareToastTimeoutRef.current) {
+        clearTimeout(shareToastTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    if (!slugParam) {
+      setAgencyDetails(null);
+      agencyDetailsRef.current = null;
+      setAgencyDetailsLoaded(true);
+      return;
+    }
+
+    const loadAgencyDetails = async () => {
+      try {
+        setAgencyDetailsLoaded(false);
+        const data = await agenciesService.getAgencyBySlug(slugParam);
+
+        if (isCancelled) {
+          return;
+        }
+
+        setAgencyDetails(data);
+        agencyDetailsRef.current = data;
+
+        if (data?.name) {
+          setAgencyDisplayName(data.name);
+        }
+      } catch (error) {
+        if (!isCancelled) {
+          console.error("Error loading agency details:", error);
+          setAgencyDetails(null);
+          agencyDetailsRef.current = null;
+        }
+      } finally {
+        if (!isCancelled) {
+          setAgencyDetailsLoaded(true);
+        }
+      }
+    };
+
+    loadAgencyDetails();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [slugParam]);
   
   // Set up listing impression tracking
   const { observeElement } = useListingImpressions({
@@ -91,23 +179,18 @@ export function AgencyPage() {
     }
   }, [user]);
 
-  // Load listings when filters, page, or slug changes
-  useEffect(() => {
-    if (slug) {
-      loadAgencyListings();
-    }
-  }, [slug, filters, currentPage]);
-
   // Set page title based on agency name
   useEffect(() => {
-    if (agencyName) {
-      document.title = `${agencyName} - Listings | HaDirot`;
+    if (resolvedAgencyDisplayName) {
+      document.title = `${resolvedAgencyDisplayName} - Listings | HaDirot`;
+    } else {
+      document.title = "HaDirot Real Estate Listings Platform";
     }
-    
+
     return () => {
       document.title = "HaDirot Real Estate Listings Platform";
     };
-  }, [agencyName]);
+  }, [resolvedAgencyDisplayName]);
 
   const loadUserFavorites = async () => {
     if (!user) return;
@@ -121,119 +204,64 @@ export function AgencyPage() {
   };
 
   const loadAgencyListings = async () => {
-    if (!slug) return;
-    
-    try {
-      setLoading(true);
-      
-      // Generate potential agency name patterns from slug
-      const agencyPatterns = slugToAgencyPatterns(slug);
-      
-      // Find the actual agency name by querying profiles
-      const { data: agencyProfiles, error: agencyError } = await supabase
-        .from('profiles')
-        .select('agency')
-        .eq('role', 'agent')
-        .not('agency', 'is', null)
-        .in('agency', agencyPatterns)
-        .limit(1);
-      
-      if (agencyError) {
-        console.error("Error finding agency:", agencyError);
-        setLoading(false);
-        return;
-      }
-      
-      if (!agencyProfiles || agencyProfiles.length === 0) {
-        console.log("No agency found for slug:", slug);
-        setAgencyName("");
-        setListings([]);
-        setTotalCount(0);
-        setLoading(false);
-        return;
-      }
-      
-      const foundAgencyName = agencyProfiles[0].agency;
-      setAgencyName(foundAgencyName);
-      
-      // Build query for listings
-      let query = supabase
-        .from('listings')
-        .select(`
-          *,
-          owner:profiles!listings_user_id_fkey(id, full_name, role, agency),
-          listing_images(*)
-        `, { count: 'exact' })
-        .eq('is_active', true)
-        .eq('approved', true)
-        .eq('profiles.role', 'agent')
-        .eq('profiles.agency', foundAgencyName);
-
-      // Apply filters
-      if (filters.bedrooms !== undefined) {
-        if (filters.bedrooms >= 4) {
-          query = query.gte('bedrooms', 4);
-        } else {
-          query = query.eq('bedrooms', filters.bedrooms);
-        }
-      }
-      
-      if (filters.min_price) {
-        query = query.gte('price', filters.min_price);
-      }
-      
-      if (filters.max_price) {
-        query = query.lte('price', filters.max_price);
-      }
-
-      // Apply sorting
-      switch (filters.sort) {
-        case 'price_asc':
-          query = query.order('price', { ascending: true });
-          break;
-        case 'price_desc':
-          query = query.order('price', { ascending: false });
-          break;
-        case 'newest':
-        default:
-          query = query.order('created_at', { ascending: false });
-          break;
-      }
-
-      // Apply pagination
-      const offset = (currentPage - 1) * ITEMS_PER_PAGE;
-      query = query.range(offset, offset + ITEMS_PER_PAGE - 1);
-
-      const { data, error, count } = await query;
-
-      if (error) {
-        console.error("Error loading agency listings:", error);
-        console.error("Query details:", { foundAgencyName, filters });
-        setListings([]);
-        setTotalCount(0);
-      } else {
-        console.log("Raw data from query:", data?.length, "listings");
-        console.log("Sample listing owner:", data?.[0]?.owner);
-        
-        setListings(data || []);
-        setTotalCount(count || 0);
-      }
-      
-      // Track agency page view
-      track('agency_page_view', {
-        agency_name: foundAgencyName,
-        agency_slug: slug,
-        listing_count: count || 0,
-      });
-      
-    } catch (error) {
-      console.error("Error in loadAgencyListings:", error);
+    if (!slugParam) {
       setListings([]);
       setTotalCount(0);
+      setAgencyDisplayName(derivedAgencyLabel);
+      setMatchedAgencyName(null);
+      setProfilesLoaded(true);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setProfilesLoaded(false);
+
+      const offset = (currentPage - 1) * ITEMS_PER_PAGE;
+      const {
+        data,
+        count,
+        agencyName: matchedName,
+      } = await listingsService.getActiveListingsForAgencySlug(slugParam, {
+        beds: filters.bedrooms,
+        priceMin: filters.min_price,
+        priceMax: filters.max_price,
+        sort: filters.sort,
+        limit: ITEMS_PER_PAGE,
+        offset,
+      });
+
+      const resolvedAgencyName = matchedName ?? derivedAgencyLabel;
+      const agencyFoundForView = Boolean(
+        (matchedName && matchedName.length > 0) || agencyDetailsRef.current,
+      );
+
+      setAgencyDisplayName(resolvedAgencyName);
+      setMatchedAgencyName(matchedName ?? null);
+      setListings(data ?? []);
+      setTotalCount(count ?? 0);
+
+      track("agency_page_view", {
+        agency_name: resolvedAgencyName,
+        agency_slug: slugParam,
+        listing_count: count ?? 0,
+        agency_found: agencyFoundForView,
+      });
+    } catch (error) {
+      console.error("Error loading agency listings:", error);
+      setListings([]);
+      setTotalCount(0);
+      setMatchedAgencyName(null);
     } finally {
       setLoading(false);
+      setProfilesLoaded(true);
     }
   };
+
+  // Load listings when filters, page, or slug changes
+  useEffect(() => {
+    loadAgencyListings();
+  }, [slugParam, filters, currentPage]);
 
   const handleFiltersChange = (newFilters: AgencyFilters) => {
     setFilters(newFilters);
@@ -260,46 +288,72 @@ export function AgencyPage() {
     
     // Track filter usage
     track('agency_filter_apply', {
-      agency_name: agencyName,
-      agency_slug: slug,
+      agency_name: resolvedAgencyDisplayName,
+      agency_slug: slugParam,
+      agency_found: agencyExists ?? false,
       filters: newFilters,
     });
   };
 
   const handlePageChange = (page: number) => {
     if (page < 1 || page > totalPages) return;
-    
+
     const params = new URLSearchParams(searchParams);
     params.set("page", page.toString());
     setSearchParams(params);
     setCurrentPage(page);
-    
+
     // Scroll to top when page changes
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
+  const showShareToast = (message: string) => {
+    setShareToastMessage(message);
+    if (shareToastTimeoutRef.current) {
+      clearTimeout(shareToastTimeoutRef.current);
+    }
+    shareToastTimeoutRef.current = window.setTimeout(() => {
+      setShareToastMessage(null);
+    }, 3000);
+  };
+
   const handleShareAgency = async () => {
     const url = window.location.href;
-    
+
     try {
       await navigator.clipboard.writeText(url);
-      // You could add a toast notification here
-      console.log("Agency page URL copied to clipboard");
-      
+      showShareToast("Link copied to clipboard");
+
       track('agency_share', {
-        agency_name: agencyName,
-        agency_slug: slug,
+        agency_name: resolvedAgencyDisplayName,
+        agency_slug: slugParam,
+        agency_found: agencyExists ?? false,
         method: 'copy_link',
       });
+      return;
     } catch (error) {
       console.error("Failed to copy URL:", error);
-      // Fallback: select the URL in a temporary input
+    }
+
+    try {
       const input = document.createElement('input');
       input.value = url;
       document.body.appendChild(input);
       input.select();
       document.execCommand('copy');
       document.body.removeChild(input);
+
+      showShareToast("Link copied to clipboard");
+
+      track('agency_share', {
+        agency_name: resolvedAgencyDisplayName,
+        agency_slug: slugParam,
+        agency_found: agencyExists ?? false,
+        method: 'copy_link',
+      });
+    } catch (fallbackError) {
+      console.error("Fallback copy failed:", fallbackError);
+      showShareToast("Unable to copy link");
     }
   };
 
@@ -307,74 +361,63 @@ export function AgencyPage() {
     loadUserFavorites();
   };
 
-  if (loading) {
-    return (
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="text-center py-12">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#273140] mx-auto"></div>
-          <p className="text-gray-600 mt-4">Loading agency listings...</p>
-        </div>
-      </div>
-    );
-  }
-
-  if (!agencyName) {
-    return (
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="text-center py-12">
-          <h1 className="text-2xl font-bold text-gray-900 mb-4">Agency Not Found</h1>
-          <p className="text-gray-600 mb-6">
-            The agency you're looking for doesn't exist or has no active listings.
-          </p>
-          <Link
-            to="/browse"
-            className="inline-flex items-center bg-accent-500 text-white px-6 py-3 rounded-md font-medium hover:bg-accent-600 transition-colors"
-          >
-            Browse All Listings
-          </Link>
-        </div>
-      </div>
-    );
-  }
+  const hasActiveFilters =
+    filters.bedrooms !== undefined ||
+    Boolean(filters.min_price) ||
+    Boolean(filters.max_price) ||
+    (filters.sort && filters.sort !== 'newest');
+  const websiteLabel = agencyDetails?.website?.trim();
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      {shareToastMessage && (
+        <div className="fixed top-24 right-4 z-50 rounded-md bg-[#273140] px-4 py-2 text-sm font-medium text-white shadow-lg">
+          {shareToastMessage}
+        </div>
+      )}
+
       {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-center justify-between mb-4">
+      <div className="mb-10 space-y-6">
+        {agencyDetails?.banner_url && (
+          <div className="h-48 md:h-60 rounded-2xl overflow-hidden border border-gray-200 shadow-sm">
+            <img
+              src={agencyDetails.banner_url}
+              alt={`${resolvedAgencyDisplayName} banner`}
+              className="w-full h-full object-cover"
+            />
+          </div>
+        )}
+
+        <div className="flex items-start gap-4">
+          {agencyDetails?.logo_url && (
+            <img
+              src={agencyDetails.logo_url}
+              alt={`${resolvedAgencyDisplayName} logo`}
+              className="w-20 h-20 md:w-24 md:h-24 rounded-full border border-gray-200 shadow-sm object-cover bg-white"
+            />
+          )}
           <div>
-            <h1 className="text-3xl font-bold font-brand text-[#273140] mb-2">
-              {agencyName}
+            <h1 className="text-3xl font-bold font-brand text-[#273140] mb-1">
+              {resolvedAgencyDisplayName}
             </h1>
             <p className="text-gray-600">
               {loading
                 ? "Loading..."
-                : `${totalCount} active listing${totalCount === 1 ? '' : 's'}`}
+                : `${totalCount} active listing${totalCount === 1 ? "" : "s"}`}
             </p>
           </div>
-          
-          <button
-            onClick={handleShareAgency}
-            className="flex items-center bg-white border border-gray-300 px-4 py-2 rounded-md text-gray-700 hover:bg-gray-50 transition-colors"
-          >
-            <Share2 className="w-4 h-4 mr-2" />
-            Share Agency
-          </button>
         </div>
       </div>
 
       {/* Mobile Filter Button */}
-      <div className="md:hidden mb-6">
+      <div className="lg:hidden mb-6">
         <button
           onClick={() => setShowFiltersMobile(true)}
           className="w-full bg-[#f9f4ed] border border-gray-200 rounded-lg p-4 flex items-center justify-center text-[#273140] hover:bg-gray-50 transition-colors"
         >
           <Filter className="w-5 h-5 mr-2" />
           <span className="font-medium">Filter Listings</span>
-          {(filters.bedrooms !== undefined ||
-            filters.min_price ||
-            filters.max_price ||
-            (filters.sort && filters.sort !== 'newest')) && (
+          {hasActiveFilters && (
             <span className="ml-2 bg-[#667B9A] text-white text-xs px-2 py-1 rounded-full">
               Active
             </span>
@@ -382,97 +425,219 @@ export function AgencyPage() {
         </button>
       </div>
 
-      {/* Desktop Filters */}
-      <div className="hidden md:block mb-6">
-        <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200">
-          <div className="flex items-center mb-4">
-            <Filter className="w-5 h-5 text-[#273140] mr-2" />
-            <h3 className="text-lg font-semibold text-[#273140]">Filters</h3>
-            <button
-              onClick={() => handleFiltersChange({})}
-              className="ml-auto text-sm text-gray-500 hover:text-[#273140] transition-colors"
-            >
-              Clear All
-            </button>
+      <div className="lg:grid lg:grid-cols-[280px_minmax(0,1fr)] lg:gap-8">
+        <aside className="hidden lg:block">
+          <div className="sticky top-32">
+            <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200">
+              <div className="flex items-center justify-between mb-4">
+                <div className="flex items-center gap-2">
+                  <Filter className="w-5 h-5 text-[#273140]" />
+                  <h3 className="text-lg font-semibold text-[#273140]">Filters</h3>
+                </div>
+                <button
+                  onClick={() => handleFiltersChange({})}
+                  className="text-sm text-gray-500 hover:text-[#273140] transition-colors"
+                >
+                  Clear All
+                </button>
+              </div>
+
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Bedrooms
+                  </label>
+                  <select
+                    value={filters.bedrooms === 0 ? "0" : filters.bedrooms || ""}
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      const bedrooms = value === "" ? undefined : parseInt(value);
+                      handleFiltersChange({ ...filters, bedrooms });
+                    }}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-[#273140] focus:border-[#273140]"
+                  >
+                    <option value="">Any</option>
+                    <option value="0">Studio</option>
+                    <option value="1">1 BR</option>
+                    <option value="2">2 BR</option>
+                    <option value="3">3 BR</option>
+                    <option value="4">4+ BR</option>
+                  </select>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Min Price
+                  </label>
+                  <input
+                    type="number"
+                    placeholder="$"
+                    value={filters.min_price || ""}
+                    onChange={(e) => {
+                      const value = parseInt(e.target.value) || undefined;
+                      handleFiltersChange({ ...filters, min_price: value });
+                    }}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-[#273140] focus:border-[#273140]"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Max Price
+                  </label>
+                  <input
+                    type="number"
+                    placeholder="$"
+                    value={filters.max_price || ""}
+                    onChange={(e) => {
+                      const value = parseInt(e.target.value) || undefined;
+                      handleFiltersChange({ ...filters, max_price: value });
+                    }}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-[#273140] focus:border-[#273140]"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Sort By
+                  </label>
+                  <select
+                    value={filters.sort || 'newest'}
+                    onChange={(e) => {
+                      const sort = e.target.value as AgencyFilters['sort'];
+                      handleFiltersChange({ ...filters, sort });
+                    }}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-[#273140] focus:border-[#273140]"
+                  >
+                    <option value="newest">Newest</option>
+                    <option value="price_asc">Price: Low to High</option>
+                    <option value="price_desc">Price: High to Low</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+          </div>
+        </aside>
+
+        <div className="space-y-6">
+          <div className="bg-white border border-gray-200 rounded-lg shadow-sm p-6">
+            <div className="flex flex-col gap-4">
+              <div>
+                <h2 className="text-2xl font-semibold text-[#273140]">
+                  {resolvedAgencyDisplayName}
+                </h2>
+                <p className="text-sm text-gray-500">
+                  {loading
+                    ? "Loading..."
+                    : `${totalCount} active listing${totalCount === 1 ? "" : "s"}`}
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-gray-600">
+                {agencyDetails?.phone && (
+                  <div className="flex items-center gap-2">
+                    <Phone className="w-4 h-4 text-[#273140]" />
+                    <span>{agencyDetails.phone}</span>
+                  </div>
+                )}
+                {agencyDetails?.email && (
+                  <a
+                    href={`mailto:${agencyDetails.email}`}
+                    className="flex items-center gap-2 hover:text-[#273140] transition-colors"
+                  >
+                    <Mail className="w-4 h-4 text-[#273140]" />
+                    <span>{agencyDetails.email}</span>
+                  </a>
+                )}
+                {websiteLabel && (
+                  <a
+                    href={normalizeUrlForHref(agencyDetails?.website ?? undefined)}
+                    target="_blank"
+                    rel="noopener noreferrer nofollow"
+                    className="flex items-center gap-2 hover:text-[#273140] transition-colors"
+                  >
+                    <Globe className="w-4 h-4 text-[#273140]" />
+                    <span>{websiteLabel}</span>
+                  </a>
+                )}
+                <button
+                  type="button"
+                  onClick={handleShareAgency}
+                  className="flex items-center gap-2 text-[#273140] hover:text-[#1b2331] transition-colors"
+                >
+                  <Share2 className="w-4 h-4" />
+                  <span>Share</span>
+                </button>
+              </div>
+              {agencyDetails?.about_html && (
+                <div className="pt-4 border-t border-gray-100">
+                  <h3 className="text-sm font-semibold uppercase tracking-wide text-[#273140] mb-3">
+                    About
+                  </h3>
+                  <div
+                    className="space-y-3 text-gray-700 leading-relaxed"
+                    dangerouslySetInnerHTML={{
+                      __html: agencyDetails.about_html ?? "",
+                    }}
+                  />
+                </div>
+              )}
+            </div>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
-            {/* Bedrooms */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Bedrooms
-              </label>
-              <select
-                value={filters.bedrooms === 0 ? "0" : filters.bedrooms || ""}
-                onChange={(e) => {
-                  const value = e.target.value;
-                  const bedrooms = value === "" ? undefined : parseInt(value);
-                  handleFiltersChange({ ...filters, bedrooms });
-                }}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-[#273140] focus:border-[#273140]"
-              >
-                <option value="">Any</option>
-                <option value="0">Studio</option>
-                <option value="1">1 BR</option>
-                <option value="2">2 BR</option>
-                <option value="3">3 BR</option>
-                <option value="4">4+ BR</option>
-              </select>
+          {loading ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
+                <div key={i} className="bg-white rounded-lg shadow-sm animate-pulse">
+                  <div className="h-48 bg-gray-200 rounded-t-lg"></div>
+                  <div className="p-4">
+                    <div className="h-4 bg-gray-200 rounded mb-2"></div>
+                    <div className="h-4 bg-gray-200 rounded w-3/4 mb-2"></div>
+                    <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+                  </div>
+                </div>
+              ))}
             </div>
+          ) : listings.length === 0 ? (
+            <div className="text-center py-12">
+              <div className="text-gray-400 mb-4">
+                <svg className="mx-auto h-12 w-12" fill="none" viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+                  />
+                </svg>
+              </div>
+              <h3 className="text-lg font-medium text-gray-900 mb-2">No listings found</h3>
+              <p className="text-gray-500">
+                {agencyExists === false
+                  ? `We couldn't find any agents for "${resolvedAgencyDisplayName}".`
+                  : `${resolvedAgencyDisplayName} doesn't have any active listings matching your criteria.`}
+              </p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {listings.map((listing) => (
+                <div
+                  key={listing.id}
+                  ref={(el) => {
+                    if (el) {
+                      observeElement(el, listing.id);
+                    }
+                  }}
+                >
+                  <ListingCard
+                    listing={listing}
+                    isFavorited={userFavorites.includes(listing.id)}
+                    onFavoriteChange={handleFavoriteChange}
+                    showFeaturedBadge={false} // Don't show featured badges on agency pages
+                  />
+                </div>
+              ))}
+            </div>
+          )}
 
-            {/* Min Price */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Min Price
-              </label>
-              <input
-                type="number"
-                placeholder="$"
-                value={filters.min_price || ""}
-                onChange={(e) => {
-                  const value = parseInt(e.target.value) || undefined;
-                  handleFiltersChange({ ...filters, min_price: value });
-                }}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-[#273140] focus:border-[#273140]"
-              />
-            </div>
-
-            {/* Max Price */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Max Price
-              </label>
-              <input
-                type="number"
-                placeholder="$"
-                value={filters.max_price || ""}
-                onChange={(e) => {
-                  const value = parseInt(e.target.value) || undefined;
-                  handleFiltersChange({ ...filters, max_price: value });
-                }}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-[#273140] focus:border-[#273140]"
-              />
-            </div>
-
-            {/* Sort */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Sort By
-              </label>
-              <select
-                value={filters.sort || 'newest'}
-                onChange={(e) => {
-                  const sort = e.target.value as AgencyFilters['sort'];
-                  handleFiltersChange({ ...filters, sort });
-                }}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-[#273140] focus:border-[#273140]"
-              >
-                <option value="newest">Newest</option>
-                <option value="price_asc">Price: Low to High</option>
-                <option value="price_desc">Price: High to Low</option>
-              </select>
-            </div>
-          </div>
         </div>
       </div>
 
@@ -480,10 +645,10 @@ export function AgencyPage() {
       {showFiltersMobile && (
         <>
           <div
-            className="fixed inset-0 bg-black bg-opacity-50 z-40 md:hidden"
+            className="fixed inset-0 bg-black bg-opacity-50 z-40 lg:hidden"
             onClick={() => setShowFiltersMobile(false)}
           />
-          <div className="fixed top-0 left-0 right-0 bottom-0 bg-white z-50 md:hidden overflow-y-auto">
+          <div className="fixed top-0 left-0 right-0 bottom-0 bg-white z-50 lg:hidden overflow-y-auto">
             <div className="flex items-center justify-between p-4 border-b border-gray-200 bg-white sticky top-0">
               <h2 className="text-lg font-semibold text-[#273140]">
                 Filter Listings
@@ -577,138 +742,7 @@ export function AgencyPage() {
         </>
       )}
 
-      {/* Listings Grid */}
-      {loading ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-          {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
-            <div key={i} className="bg-white rounded-lg shadow-sm animate-pulse">
-              <div className="h-48 bg-gray-200 rounded-t-lg"></div>
-              <div className="p-4">
-                <div className="h-4 bg-gray-200 rounded mb-2"></div>
-                <div className="h-4 bg-gray-200 rounded w-3/4 mb-2"></div>
-                <div className="h-4 bg-gray-200 rounded w-1/2"></div>
-              </div>
-            </div>
-          ))}
-        </div>
-      ) : listings.length === 0 ? (
-        <div className="text-center py-12">
-          <div className="text-gray-400 mb-4">
-            <svg className="mx-auto h-12 w-12" fill="none" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-              />
-            </svg>
-          </div>
-          <h3 className="text-lg font-medium text-gray-900 mb-2">
-            No listings found
-          </h3>
-          <p className="text-gray-500">
-            {agencyName} doesn't have any active listings matching your criteria.
-          </p>
-        </div>
-      ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-          {listings.map((listing) => (
-            <div 
-              key={listing.id}
-              ref={(el) => {
-                if (el) {
-                  observeElement(el, listing.id);
-                }
-              }}
-            >
-              <ListingCard
-                listing={listing}
-                isFavorited={userFavorites.includes(listing.id)}
-                onFavoriteChange={handleFavoriteChange}
-                showFeaturedBadge={false} // Don't show featured badges on agency pages
-              />
-            </div>
-          ))}
-        </div>
-      )}
 
-      {/* Pagination */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-center space-x-2 mt-12">
-          <button
-            onClick={() => handlePageChange(currentPage - 1)}
-            disabled={currentPage === 1}
-            className="flex items-center px-3 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            <ChevronLeft className="w-4 h-4 mr-1" />
-            Previous
-          </button>
-
-          <div className="flex space-x-1">
-            {currentPage > 1 && (
-              <button
-                onClick={() => handlePageChange(1)}
-                className="px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
-              >
-                1
-              </button>
-            )}
-
-            {currentPage > 3 && (
-              <span className="px-3 py-2 text-sm text-gray-500">...</span>
-            )}
-
-            {(() => {
-              const startPage = Math.max(1, currentPage - 1);
-              const endPage = Math.min(totalPages, currentPage + 1);
-              const pages = [];
-
-              for (let pageNum = startPage; pageNum <= endPage; pageNum++) {
-                if (pageNum === 1 && currentPage > 1) continue;
-                if (pageNum === totalPages && currentPage < totalPages) continue;
-
-                pages.push(
-                  <button
-                    key={pageNum}
-                    onClick={() => handlePageChange(pageNum)}
-                    className={`px-3 py-2 text-sm font-medium rounded-md transition-colors ${
-                      pageNum === currentPage
-                        ? "bg-brand-700 text-white"
-                        : "text-gray-700 bg-white border border-gray-300 hover:bg-gray-50"
-                    }`}
-                  >
-                    {pageNum}
-                  </button>
-                );
-              }
-
-              return pages;
-            })()}
-
-            {currentPage < totalPages - 2 && (
-              <span className="px-3 py-2 text-sm text-gray-500">...</span>
-            )}
-
-            {currentPage < totalPages && (
-              <button
-                onClick={() => handlePageChange(totalPages)}
-                className="px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
-              >
-                {totalPages}
-              </button>
-            )}
-          </div>
-
-          <button
-            onClick={() => handlePageChange(currentPage + 1)}
-            disabled={currentPage === totalPages}
-            className="flex items-center px-3 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            Next
-            <ChevronRight className="w-4 h-4 ml-1" />
-          </button>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/pages/AgencySettings.tsx
+++ b/src/pages/AgencySettings.tsx
@@ -1,0 +1,760 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Link, Navigate } from "react-router-dom";
+import {
+  ArrowLeft,
+  Upload,
+  Trash2,
+  Loader2,
+  ExternalLink,
+  Save,
+  Bold,
+  Italic,
+  List,
+  ListOrdered,
+  Heading2,
+  Link as LinkIcon,
+  CheckCircle2,
+  AlertCircle,
+  Paintbrush,
+} from "lucide-react";
+import { useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import LinkExtension from "@tiptap/extension-link";
+import { useAuth } from "@/hooks/useAuth";
+import { agencyNameToSlug } from "@/utils/agency";
+import { agenciesService } from "@/services/agencies";
+import { Agency } from "@/config/supabase";
+import { listingsService } from "@/services/listings";
+import "@/styles/editor.css";
+
+interface FormState {
+  name: string;
+  logo_url: string;
+  banner_url: string;
+  phone: string;
+  email: string;
+  website: string;
+  about_html: string;
+}
+
+export function AgencySettings() {
+  const { user, profile, loading: authLoading } = useAuth();
+  const agencyName = profile?.agency?.trim() ?? "";
+  const slug = useMemo(() => agencyNameToSlug(agencyName), [agencyName]);
+  const canManageAgency =
+    profile?.role === "agent" &&
+    agencyName.length > 0 &&
+    profile?.can_manage_agency === true;
+
+  const [agency, setAgency] = useState<Agency | null>(null);
+  const [formState, setFormState] = useState<FormState>({
+    name: agencyName,
+    logo_url: "",
+    banner_url: "",
+    phone: "",
+    email: "",
+    website: "",
+    about_html: "",
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [logoUploading, setLogoUploading] = useState(false);
+  const [bannerUploading, setBannerUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const initialEditorSyncRef = useRef(false);
+
+  const extensions = useMemo(
+    () => [
+      StarterKit.configure({
+        heading: {
+          levels: [2, 3],
+        },
+      }),
+      LinkExtension.configure({
+        openOnClick: false,
+        HTMLAttributes: {
+          class: "text-[#273140] underline",
+          target: "_blank",
+          rel: "noopener noreferrer",
+        },
+      }),
+    ],
+    [],
+  );
+
+  const editor = useEditor({
+    extensions,
+    content: "",
+    onUpdate({ editor }) {
+      setSuccess(null);
+      setFormState((prev) => ({
+        ...prev,
+        about_html: editor.getHTML(),
+      }));
+    },
+  });
+
+  const toolbarButtonClass = (active?: boolean) =>
+    `inline-flex items-center justify-center rounded-md border px-2 py-1 text-sm transition-colors ${
+      active
+        ? "border-[#273140] bg-[#273140] text-white"
+        : "border-gray-200 text-gray-600 hover:bg-gray-100"
+    }`;
+
+  const toNullable = (value: string) => {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  };
+
+  const loadAgencyDetails = useCallback(async () => {
+    if (!slug) {
+      setAgency(null);
+      initialEditorSyncRef.current = false;
+      setFormState({
+        name: agencyName,
+        logo_url: "",
+        banner_url: "",
+        phone: "",
+        email: "",
+        website: "",
+        about_html: "",
+      });
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await agenciesService.getAgencyBySlug(slug);
+      setAgency(data);
+
+      const nextState: FormState = {
+        name: data?.name?.trim() || agencyName,
+        logo_url: data?.logo_url ?? "",
+        banner_url: data?.banner_url ?? "",
+        phone: data?.phone ?? "",
+        email: data?.email ?? "",
+        website: data?.website ?? "",
+        about_html: data?.about_html ?? "",
+      };
+
+      initialEditorSyncRef.current = false;
+      setFormState(nextState);
+    } catch (err) {
+      console.error("Error loading agency settings:", err);
+      setAgency(null);
+      initialEditorSyncRef.current = false;
+      setFormState({
+        name: agencyName,
+        logo_url: "",
+        banner_url: "",
+        phone: "",
+        email: "",
+        website: "",
+        about_html: "",
+      });
+      setError("Failed to load agency settings. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, [agencyName, slug]);
+
+  useEffect(() => {
+    if (!canManageAgency || !slug) {
+      setLoading(false);
+      return;
+    }
+
+    loadAgencyDetails();
+  }, [canManageAgency, slug, loadAgencyDetails]);
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    if (initialEditorSyncRef.current) {
+      return;
+    }
+
+    editor.commands.setContent(formState.about_html || "<p></p>");
+    initialEditorSyncRef.current = true;
+  }, [editor, formState.about_html]);
+
+  const handleInputChange = (field: keyof FormState) =>
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const { value } = event.target;
+      setSuccess(null);
+      setFormState((prev) => ({ ...prev, [field]: value }));
+    };
+
+  const handleLogoUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    if (!user) {
+      setError("You must be signed in to upload images.");
+      return;
+    }
+
+    const file = event.target.files?.[0];
+    event.target.value = "";
+
+    if (!file) {
+      return;
+    }
+
+    setLogoUploading(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const { publicUrl } = await listingsService.uploadTempListingImage(
+        file,
+        user.id,
+      );
+      setFormState((prev) => ({ ...prev, logo_url: publicUrl }));
+    } catch (err) {
+      console.error("Error uploading logo:", err);
+      setError("Failed to upload logo. Please try again.");
+    } finally {
+      setLogoUploading(false);
+    }
+  };
+
+  const handleBannerUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    if (!user) {
+      setError("You must be signed in to upload images.");
+      return;
+    }
+
+    const file = event.target.files?.[0];
+    event.target.value = "";
+
+    if (!file) {
+      return;
+    }
+
+    setBannerUploading(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const { publicUrl } = await listingsService.uploadTempListingImage(
+        file,
+        user.id,
+      );
+      setFormState((prev) => ({ ...prev, banner_url: publicUrl }));
+    } catch (err) {
+      console.error("Error uploading banner:", err);
+      setError("Failed to upload banner. Please try again.");
+    } finally {
+      setBannerUploading(false);
+    }
+  };
+
+  const handleToggleLink = () => {
+    if (!editor) {
+      return;
+    }
+
+    if (editor.isActive("link")) {
+      editor.chain().focus().extendMarkRange("link").unsetLink().run();
+      return;
+    }
+
+    const previous = editor.getAttributes("link").href as string | undefined;
+    const url = window.prompt("Enter link URL", previous || "https://");
+
+    if (url === null || url.trim() === "") {
+      return;
+    }
+
+    editor
+      .chain()
+      .focus()
+      .extendMarkRange("link")
+      .setLink({
+        href: url,
+        target: "_blank",
+        rel: "noopener noreferrer",
+      })
+      .run();
+  };
+
+  const handleCreateAgency = async () => {
+    if (!slug || agencyName.length === 0) {
+      return;
+    }
+
+    setCreating(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const created = await agenciesService.createAgency({
+        name: agencyName,
+        slug,
+      });
+
+      setAgency(created);
+      const nextState: FormState = {
+        name: created?.name?.trim() || agencyName,
+        logo_url: created?.logo_url ?? "",
+        banner_url: created?.banner_url ?? "",
+        phone: created?.phone ?? "",
+        email: created?.email ?? "",
+        website: created?.website ?? "",
+        about_html: created?.about_html ?? "",
+      };
+
+      initialEditorSyncRef.current = false;
+      setFormState(nextState);
+      setSuccess("Agency profile created. You can now customize your branding.");
+    } catch (err) {
+      console.error("Error creating agency:", err);
+      setError("Failed to create agency profile. Please try again.");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleSave = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!agency) {
+      return;
+    }
+
+    const trimmedName = formState.name.trim();
+    if (!trimmedName) {
+      setError("Agency name is required.");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const payload = {
+        name: trimmedName,
+        logo_url: toNullable(formState.logo_url),
+        banner_url: toNullable(formState.banner_url),
+        phone: toNullable(formState.phone),
+        email: toNullable(formState.email),
+        website: toNullable(formState.website),
+        about_html: formState.about_html,
+      };
+
+      const updated = await agenciesService.updateAgencyById(
+        agency.id,
+        payload,
+      );
+
+      const nextAgency = updated ?? agency;
+      setAgency(nextAgency);
+
+      const nextState: FormState = {
+        name: nextAgency.name?.trim() || trimmedName,
+        logo_url: nextAgency.logo_url ?? "",
+        banner_url: nextAgency.banner_url ?? "",
+        phone: nextAgency.phone ?? "",
+        email: nextAgency.email ?? "",
+        website: nextAgency.website ?? "",
+        about_html: nextAgency.about_html ?? "",
+      };
+
+      initialEditorSyncRef.current = false;
+      setFormState(nextState);
+      setSuccess("Agency profile updated successfully.");
+    } catch (err) {
+      console.error("Error saving agency settings:", err);
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to save agency settings. Please try again.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const isUnauthorized =
+    !authLoading && (!user || !canManageAgency || !slug);
+
+  if (isUnauthorized) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  if (authLoading || loading) {
+    return (
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="flex flex-col items-center justify-center text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#273140] mb-4" />
+          <p className="text-gray-600">Loading agency settings...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const handleRemoveLogo = () => {
+    setSuccess(null);
+    setFormState((prev) => ({ ...prev, logo_url: "" }));
+  };
+
+  const handleRemoveBanner = () => {
+    setSuccess(null);
+    setFormState((prev) => ({ ...prev, banner_url: "" }));
+  };
+
+  const isSavingDisabled = saving || logoUploading || bannerUploading;
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-8">
+        <div>
+          <h1 className="text-3xl font-bold text-[#273140] mb-1">
+            Agency Branding
+          </h1>
+          <p className="text-gray-600">
+            Customize the public profile and contact details for your agency.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <Link
+            to="/dashboard"
+            className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to Dashboard
+          </Link>
+          {slug && (
+            <a
+              href={`/agencies/${slug}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-md border border-[#273140] bg-[#273140] px-3 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-[#1f2935]"
+            >
+              <ExternalLink className="w-4 h-4" />
+              View Live
+            </a>
+          )}
+        </div>
+      </div>
+
+      {slug && (
+        <div className="mb-6 rounded-lg border border-dashed border-gray-300 bg-[#f9f4ed] px-4 py-3 text-sm text-[#273140]">
+          Public URL: <span className="font-semibold">/agencies/{slug}</span>
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <AlertCircle className="w-4 h-4 mt-0.5" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {success && (
+        <div className="mb-4 flex items-start gap-2 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+          <CheckCircle2 className="w-4 h-4 mt-0.5" />
+          <span>{success}</span>
+        </div>
+      )}
+
+      {!agency ? (
+        <div className="rounded-xl border border-dashed border-gray-300 bg-white px-6 py-10 text-center shadow-sm">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-[#f0e7da]">
+            <Paintbrush className="h-6 w-6 text-[#273140]" />
+          </div>
+          <h2 className="text-xl font-semibold text-[#273140] mb-2">
+            Set up your agency profile
+          </h2>
+          <p className="text-gray-600 max-w-xl mx-auto mb-6">
+            Create an agency record to control the branding, contact details, and
+            about section that appear on your public agency page.
+          </p>
+          <button
+            type="button"
+            onClick={handleCreateAgency}
+            disabled={creating}
+            className="inline-flex items-center gap-2 rounded-md bg-[#273140] px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-[#1f2935] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {creating ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Paintbrush className="w-4 h-4" />
+            )}
+            {creating ? "Creating..." : "Create Agency Profile"}
+          </button>
+        </div>
+      ) : (
+        <form onSubmit={handleSave} className="space-y-8">
+          <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm space-y-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Agency Display Name
+              </label>
+              <input
+                type="text"
+                value={formState.name}
+                onChange={handleInputChange("name")}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-[#273140] focus:outline-none focus:ring-2 focus:ring-[#273140]/20"
+                placeholder="Agency name"
+                maxLength={120}
+              />
+              <p className="mt-1 text-sm text-gray-500">
+                This name appears at the top of your public agency page.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <label className="text-sm font-medium text-gray-700">
+                    Logo
+                  </label>
+                  {formState.logo_url && (
+                    <button
+                      type="button"
+                      onClick={handleRemoveLogo}
+                      className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-[#273140]"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                      Remove
+                    </button>
+                  )}
+                </div>
+                <div className="flex items-center gap-4">
+                  <div className="flex h-20 w-20 items-center justify-center overflow-hidden rounded-full border border-dashed border-gray-300 bg-gray-50">
+                    {formState.logo_url ? (
+                      <img
+                        src={formState.logo_url}
+                        alt="Agency logo preview"
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <span className="text-xs text-gray-500">No logo</span>
+                    )}
+                  </div>
+                  <label className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50">
+                    {logoUploading ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <Upload className="w-4 h-4" />
+                    )}
+                    <span>{logoUploading ? "Uploading..." : "Upload Logo"}</span>
+                    <input
+                      type="file"
+                      accept="image/*"
+                      className="hidden"
+                      onChange={handleLogoUpload}
+                      disabled={logoUploading}
+                    />
+                  </label>
+                </div>
+                <p className="text-xs text-gray-500">
+                  Recommended: square PNG with transparent background.
+                </p>
+              </div>
+
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <label className="text-sm font-medium text-gray-700">
+                    Banner
+                  </label>
+                  {formState.banner_url && (
+                    <button
+                      type="button"
+                      onClick={handleRemoveBanner}
+                      className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-[#273140]"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                      Remove
+                    </button>
+                  )}
+                </div>
+                <div className="relative h-32 overflow-hidden rounded-lg border border-dashed border-gray-300 bg-gray-50">
+                  {formState.banner_url ? (
+                    <img
+                      src={formState.banner_url}
+                      alt="Agency banner preview"
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-full items-center justify-center text-xs text-gray-500">
+                      No banner uploaded
+                    </div>
+                  )}
+                </div>
+                <label className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50">
+                  {bannerUploading ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <Upload className="w-4 h-4" />
+                  )}
+                  <span>{bannerUploading ? "Uploading..." : "Upload Banner"}</span>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleBannerUpload}
+                    disabled={bannerUploading}
+                  />
+                </label>
+                <p className="text-xs text-gray-500">
+                  Recommended: 1200x400 JPG or PNG.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm space-y-6">
+            <h2 className="text-lg font-semibold text-[#273140]">
+              Contact Details
+            </h2>
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Phone
+                </label>
+                <input
+                  type="tel"
+                  value={formState.phone}
+                  onChange={handleInputChange("phone")}
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-[#273140] focus:outline-none focus:ring-2 focus:ring-[#273140]/20"
+                  placeholder="(555) 123-4567"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Email
+                </label>
+                <input
+                  type="email"
+                  value={formState.email}
+                  onChange={handleInputChange("email")}
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-[#273140] focus:outline-none focus:ring-2 focus:ring-[#273140]/20"
+                  placeholder="hello@agency.com"
+                />
+              </div>
+              <div className="md:col-span-2">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Website
+                </label>
+                <input
+                  type="url"
+                  value={formState.website}
+                  onChange={handleInputChange("website")}
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-[#273140] focus:outline-none focus:ring-2 focus:ring-[#273140]/20"
+                  placeholder="https://example.com"
+                />
+                <p className="mt-1 text-xs text-gray-500">
+                  Include the full URL so visitors can navigate directly to your site.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-[#273140]">About</h2>
+              <span className="text-sm text-gray-500">
+                Share your mission, experience, or specialties.
+              </span>
+            </div>
+            <div className="rounded-lg border border-gray-200">
+              <div className="flex flex-wrap items-center gap-2 border-b border-gray-200 bg-gray-50 px-3 py-2">
+                <button
+                  type="button"
+                  onClick={() => editor?.chain().focus().toggleBold().run()}
+                  disabled={!editor}
+                  className={`${toolbarButtonClass(editor?.isActive("bold"))} disabled:cursor-not-allowed disabled:opacity-50`}
+                >
+                  <Bold className="w-4 h-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => editor?.chain().focus().toggleItalic().run()}
+                  disabled={!editor}
+                  className={`${toolbarButtonClass(editor?.isActive("italic"))} disabled:cursor-not-allowed disabled:opacity-50`}
+                >
+                  <Italic className="w-4 h-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    editor?.chain().focus().toggleHeading({ level: 2 }).run()
+                  }
+                  disabled={!editor}
+                  className={`${toolbarButtonClass(
+                    editor?.isActive("heading", { level: 2 }),
+                  )} disabled:cursor-not-allowed disabled:opacity-50`}
+                >
+                  <Heading2 className="w-4 h-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => editor?.chain().focus().toggleBulletList().run()}
+                  disabled={!editor}
+                  className={`${toolbarButtonClass(editor?.isActive("bulletList"))} disabled:cursor-not-allowed disabled:opacity-50`}
+                >
+                  <List className="w-4 h-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    editor?.chain().focus().toggleOrderedList().run()
+                  }
+                  disabled={!editor}
+                  className={`${toolbarButtonClass(editor?.isActive("orderedList"))} disabled:cursor-not-allowed disabled:opacity-50`}
+                >
+                  <ListOrdered className="w-4 h-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={handleToggleLink}
+                  disabled={!editor}
+                  className={`${toolbarButtonClass(editor?.isActive("link"))} disabled:cursor-not-allowed disabled:opacity-50`}
+                >
+                  <LinkIcon className="w-4 h-4" />
+                </button>
+              </div>
+              <div className="editor-shell">
+                <EditorContent editor={editor} />
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-end gap-3">
+            <button
+              type="submit"
+              disabled={isSavingDisabled}
+              className="inline-flex items-center gap-2 rounded-md bg-[#273140] px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-[#1f2935] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {saving ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Save className="w-4 h-4" />
+              )}
+              {saving ? "Saving..." : "Save Changes"}
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,519 +1,615 @@
 import React, { useState, useEffect } from "react";
-import { Link, useNavigate, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 import {
-  Home,
-  Search,
-  Plus,
-  User,
-  Heart,
-  LogOut,
-  Settings,
-  LayoutDashboard,
-  FileText,
-  Edit3,
+  Edit,
+  Eye,
   Star,
-  BarChart3,
-  Menu,
-  X,
+  Trash2,
+  RefreshCw,
+  Plus,
+  EyeOff,
+  AlertTriangle,
 } from "lucide-react";
-import { useAuth, AUTH_CONTEXT_ID } from "@/hooks/useAuth";
-import { usePageTracking } from "../../hooks/usePageTracking";
-import { useAnalyticsAuth } from "@/lib/analytics";
-import { Footer } from "./Footer";
-import { capitalizeName } from "../../utils/formatters";
+import { useAuth } from "@/hooks/useAuth";
+import { Listing } from "../config/supabase";
+import { listingsService } from "../services/listings";
+import { profilesService } from "../services/profiles";
+import { emailService } from "../services/email";
 
-interface LayoutProps {
-  children: React.ReactNode;
-}
-
-export function Layout({ children }: LayoutProps) {
-  const { user, profile, signOut, loading, authContextId } = useAuth();
-  
-  // Initialize analytics tracking
-  usePageTracking();
-  useAnalyticsAuth();
-  
-  const navigate = useNavigate();
-  const location = useLocation();
-  const [showUserMenu, setShowUserMenu] = useState(false);
-  const [showSignOutMessage, setShowSignOutMessage] = useState(false);
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const userMenuRef = React.useRef<HTMLDivElement>(null);
-  const prevUserRef = React.useRef<typeof user>(null);
-  const prevPathnameRef = React.useRef<string>(location.pathname);
-
-  // Close dropdown menu when user logs in
-  useEffect(() => {
-    // If user was null (logged out) and now has a value (logged in)
-    if (prevUserRef.current === null && user !== null) {
-      setShowUserMenu(false);
-    }
-    prevUserRef.current = user;
-  }, [user]);
-
-  // Close dropdown menu on navigation
-  useEffect(() => {
-    if (location.pathname !== prevPathnameRef.current) {
-      setShowUserMenu(false);
-      setIsMobileMenuOpen(false);
-      prevPathnameRef.current = location.pathname;
-    }
-  }, [location.pathname]);
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        userMenuRef.current &&
-        !userMenuRef.current.contains(event.target as Node)
-      ) {
-        setShowUserMenu(false);
-      }
-    };
-
-    if (showUserMenu) {
-      document.addEventListener("mousedown", handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [showUserMenu]);
+export default function Dashboard() {
+  const { user, profile, loading: authLoading, refreshProfile } = useAuth();
+  const [listings, setListings] = useState<Listing[]>([]);
+  const [adminSettings, setAdminSettings] = useState<{
+    max_featured_listings: number;
+    max_featured_per_user: number;
+  } | null>(null);
+  const [globalFeaturedCount, setGlobalFeaturedCount] = useState<number>(0);
+  const [currentUserProfile, setCurrentUserProfile] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
 
   useEffect(() => {
-    const payload = {
-      loading,
-      userPresent: !!user,
-      profilePresent: profile !== undefined,
-      isAdmin: !!profile?.is_admin,
-      authContextId,
-    };
-    if (authContextId !== AUTH_CONTEXT_ID) {
-      console.warn("[Layout] auth context mismatch", payload);
-    } else {
-      console.log("[Layout] auth", payload);
+    if (user && !authLoading) {
+      loadUserListings();
+      loadAdminSettings();
+      loadCurrentUserProfile();
+      loadGlobalFeaturedCount();
     }
-  }, [loading, user, profile, authContextId]);
+  }, [user, authLoading]);
 
-  const handleSignOut = async () => {
+  const loadAdminSettings = async () => {
     try {
-      await signOut();
-      setIsMobileMenuOpen(false);
-      setShowSignOutMessage(true);
-      setTimeout(() => setShowSignOutMessage(false), 3000);
-      navigate("/");
+      const settings = await listingsService.getAdminSettings();
+      setAdminSettings(settings);
     } catch (error) {
-      console.error("Error signing out:", error);
+      console.error("Error loading admin settings:", error);
     }
   };
 
-  const Logo = () => (
-    <div className="font-brand uppercase tracking-wide text-xl md:text-2xl">
-      HADIROT
-    </div>
-  );
+  const loadGlobalFeaturedCount = async () => {
+    try {
+      const count = await listingsService.getGlobalFeaturedCount();
+      setGlobalFeaturedCount(count);
+    } catch (error) {
+      console.error("Error loading global featured count:", error);
+    }
+  };
+
+  const loadCurrentUserProfile = async () => {
+    if (!user) return;
+
+    try {
+      const profileData = await profilesService.getProfile(user.id);
+      setCurrentUserProfile(profileData);
+    } catch (error) {
+      console.error("Error loading current user profile:", error);
+    }
+  };
+
+  const loadUserListings = async () => {
+    if (!user) return;
+
+    try {
+      const data = await listingsService.getUserListings(user.id);
+      setListings(data);
+    } catch (error) {
+      console.error("Error loading user listings:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleToggleFeature = async (
+    listingId: string,
+    isFeatured: boolean,
+  ) => {
+    setActionLoading(listingId);
+    try {
+      const updates: any = { is_featured: !isFeatured };
+
+      // The service layer will handle setting featured_expires_at automatically
+
+      await listingsService.updateListing(listingId, updates);
+
+      // Send email notification for featured status change
+      try {
+        if (user?.email && profile?.full_name) {
+          const listing = listings.find((l) => l.id === listingId);
+          if (listing) {
+            await emailService.sendListingFeaturedEmail(
+              user.email,
+              profile.full_name,
+              listing.title,
+              !isFeatured, // New featured status (opposite of current)
+            );
+            console.log("✅ Email sent: featured status change to", user.email);
+          }
+        }
+      } catch (emailError) {
+        console.error(
+          "❌ Email failed: featured status change -",
+          emailError.message,
+        );
+        // Don't block the user flow if email fails
+      }
+
+      await loadUserListings();
+      // Refresh user profile to get updated permissions and limits
+      await refreshProfile();
+    } catch (error) {
+      console.error("Error toggling featured status:", error);
+
+      // Show specific error messages based on the error
+      let errorMessage = "Failed to update listing. Please try again.";
+      if (error instanceof Error) {
+        if (error.message.includes("permission")) {
+          errorMessage =
+            "You do not have permission to feature listings. Please contact support to upgrade your account.";
+        } else if (
+          error.message.includes("sitewide maximum") ||
+          error.message.includes("platform only allows")
+        ) {
+          errorMessage =
+            "The website limit for featured listings has been reached. Please try again later.";
+        } else if (error.message.includes("You can only feature")) {
+          errorMessage = error.message;
+        }
+      }
+
+      alert(errorMessage);
+    } finally {
+      setActionLoading(null);
+      // Refresh global state to update UI limits
+      await loadAdminSettings();
+      await loadGlobalFeaturedCount();
+    }
+  };
+
+  const handleRenewListing = async (listingId: string) => {
+    setActionLoading(listingId);
+    try {
+      await listingsService.updateListing(listingId, {
+        last_published_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        is_active: true,
+      });
+
+      // Send email notification for listing reactivation
+      try {
+        if (user?.email && profile?.full_name) {
+          const listing = listings.find((l) => l.id === listingId);
+          if (listing) {
+            await emailService.sendListingReactivationEmail(
+              user.email,
+              profile.full_name,
+              listing.title,
+            );
+            console.log("✅ Email sent: listing reactivation to", user.email);
+          }
+        }
+      } catch (emailError) {
+        console.error(
+          "❌ Email failed: listing reactivation -",
+          emailError.message,
+        );
+        // Don't block the user flow if email fails
+      }
+
+      await loadUserListings();
+    } catch (error) {
+      console.error("Error renewing listing:", error);
+      alert("Failed to renew listing. Please try again.");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleUnpublishListing = async (listingId: string) => {
+    if (
+      !confirm(
+        "Are you sure you want to unpublish this listing? It will be hidden from public view but can be republished later.",
+      )
+    ) {
+      return;
+    }
+
+    setActionLoading(listingId);
+    try {
+      await listingsService.updateListing(listingId, {
+        is_active: false,
+        updated_at: new Date().toISOString(),
+      });
+      await loadUserListings();
+
+      // Send email notification
+      try {
+        if (user?.email && profile?.full_name) {
+          const listing = listings.find((l) => l.id === listingId);
+          if (listing) {
+            await emailService.sendListingDeactivationEmail(
+              user.email,
+              profile.full_name,
+              listing.title,
+            );
+            console.log("✅ Email sent: listing deactivation to", user.email);
+          }
+        }
+      } catch (emailError) {
+        console.error(
+          "❌ Email failed: listing deactivation -",
+          emailError.message,
+        );
+        // Don't block the user flow if email fails
+      }
+    } catch (error) {
+      console.error("Error unpublishing listing:", error);
+      alert("Failed to unpublish listing. Please try again.");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+  const handleDeleteListing = async (listingId: string) => {
+    if (
+      !confirm(
+        "Are you sure you want to permanently delete this listing? This action cannot be undone.",
+      )
+    ) {
+      return;
+    }
+
+    // Store listing data before deletion for email
+    const listingToDelete = listings.find((l) => l.id === listingId);
+
+    setActionLoading(listingId);
+    try {
+      await listingsService.deleteListing(listingId);
+      // Remove from UI immediately on success
+      setListings((prev) => prev.filter((listing) => listing.id !== listingId));
+
+      // Send email notification
+      try {
+        if (user?.email && profile?.full_name && listingToDelete) {
+          await emailService.sendListingDeletedEmail(
+            user.email,
+            profile.full_name,
+            listingToDelete.title,
+          );
+          console.log("✅ Email sent: listing deletion to", user.email);
+        }
+      } catch (emailError) {
+        console.error(
+          "❌ Email failed: listing deletion -",
+          emailError.message,
+        );
+        // Don't block the user flow if email fails
+      }
+
+      console.log("✅ Listing deleted successfully");
+    } catch (error) {
+      console.error("❌ Error deleting listing:", error);
+      alert("Failed to delete listing. Please try again.");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const formatPrice = (price: number | null) => {
+    if (price == null) return "";
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(price);
+  };
+
+  // Calculate user's effective featured limit and current count
+  const effectiveUserFeaturedLimit = (currentUserProfile || profile)?.is_admin
+    ? Infinity
+    : ((currentUserProfile || profile)?.max_featured_listings_per_user ??
+      adminSettings?.max_featured_per_user ??
+      0);
+
+  const currentUserFeaturedCount = listings.filter(
+    (listing) =>
+      listing.is_featured &&
+      (!listing.featured_expires_at ||
+        new Date(listing.featured_expires_at) > new Date()),
+  ).length;
+
+  const globalLimitReached = adminSettings
+    ? globalFeaturedCount >= adminSettings.max_featured_listings
+    : false;
+  const canFeatureMore =
+    (currentUserProfile || profile)?.is_admin ||
+    currentUserFeaturedCount < effectiveUserFeaturedLimit;
+
+  // Helper function to check if a listing is actually featured (not expired)
+  const isListingCurrentlyFeatured = (listing: Listing) => {
+    return (
+      listing.is_featured &&
+      listing.featured_expires_at &&
+      new Date(listing.featured_expires_at) > new Date()
+    );
+  };
+  if (authLoading) {
+    return (
+      <div className="max-w-6xl mx-auto px-4 py-10 text-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#4E4B43] mx-auto"></div>
+        <p className="text-gray-600 mt-4">Loading...</p>
+      </div>
+    );
+  }
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <header className="sticky top-0 z-50 bg-brand-800 text-white border-b border-black/5 shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 md:px-6 h-14 md:h-16 flex items-center justify-between">
-          {/* Left spacer for balance */}
-          <div className="flex-1"></div>
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+      {/* Banned User Warning Banner */}
+      {(currentUserProfile || profile)?.is_banned && (
+        <div className="mb-6 bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="flex items-center">
+            <AlertTriangle className="w-5 h-5 text-red-600 mr-3 flex-shrink-0" />
+            <div className="text-red-800">
+              <p className="font-medium">
+                🚫 Your account has been banned. Your listings are hidden from
+                public view.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
 
-          {/* Centered Logo */}
-          <Link to="/" className="flex-shrink-0">
-            <Logo />
+      <h1 className="text-3xl font-bold text-[#273140] mb-4">
+        Welcome back
+        {(currentUserProfile || profile)?.full_name
+          ? `, ${(currentUserProfile || profile).full_name}`
+          : ""}
+        !
+      </h1>
+
+      <div>
+        <div className="flex items-center justify-between mb-6">
+          <p className="text-gray-600">Manage your property listings</p>
+          <Link
+            to="/post"
+            className="bg-accent-500 text-white px-4 py-2 rounded-md font-medium hover:bg-accent-600 transition-colors flex items-center"
+          >
+            <Plus className="w-4 h-4 mr-2" />
+            Add New Listing
           </Link>
-
-          {/* Right side navigation */}
-          <div className="flex-1 flex justify-end">
-            <nav className="hidden md:flex items-center space-x-4">
-              <Link
-                to="/browse"
-                className={`flex items-center px-3 py-2 text-sm font-medium rounded-md transition-opacity text-white hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/40 ${
-                  location.pathname === "/browse" ? "opacity-90" : ""
-                }`}
-              >
-                <Search className="w-4 h-4 mr-2" />
-                Browse
-              </Link>
-              <Link
-                to="/post"
-                className={`flex items-center px-3 py-2 text-sm font-medium rounded-md transition-opacity text-white hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/40 ${
-                  location.pathname === "/post" ? "opacity-90" : ""
-                }`}
-              >
-                <Plus className="w-4 h-4 mr-2" />
-                Post
-              </Link>
-            </nav>
-
-            <div className="hidden md:flex items-center ml-4">
-              {user ? (
-                <div className="relative" ref={userMenuRef}>
-                  <button
-                    onClick={() => setShowUserMenu(!showUserMenu)}
-                    className="flex items-center space-x-2 text-white hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-white/40"
-                  >
-                    <User className="w-5 h-5" />
-                    <span className="hidden sm:inline text-sm font-medium">
-                      {profile?.full_name
-                        ? capitalizeName(profile.full_name)
-                        : ""}
-                    </span>
-                  </button>
-
-                  {showUserMenu && (
-                    <div className="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg border border-gray-200 z-50">
-                      <div className="py-1">
-                        <div className="px-4 py-2 text-sm text-gray-500 border-b">
-                          {profile?.role === "agent" && profile?.agency && (
-                            <span className="block">{profile.agency}</span>
-                          )}
-                          <span className="capitalize">{profile?.role}</span>
-                        </div>
-                        <Link
-                          to="/account-settings"
-                          className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                          onClick={() => setShowUserMenu(false)}
-                        >
-                          <User className="w-4 h-4 mr-2" />
-                          Account
-                        </Link>
-                        <Link
-                          to="/dashboard"
-                          className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                          onClick={() => setShowUserMenu(false)}
-                        >
-                          <LayoutDashboard className="w-4 h-4 mr-2" />
-                          My Dashboard
-                        </Link>
-                        <Link
-                          to="/favorites"
-                          className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                          onClick={() => setShowUserMenu(false)}
-                        >
-                          <Heart className="w-4 h-4 mr-2" />
-                          My Favorites
-                        </Link>
-                        {/* Debug log to check profile and loading state */}
-
-                        {!loading && profile?.is_admin && (
-                          <>
-                            <Link
-                              to="/admin"
-                              className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                              onClick={() => setShowUserMenu(false)}
-                            >
-                              <Settings className="w-4 h-4 mr-2" />
-                              Admin Panel
-                            </Link>
-                            <Link
-                              to="/admin/static-pages"
-                              className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                              onClick={() => setShowUserMenu(false)}
-                            >
-                              <FileText className="w-4 h-4 mr-2" />
-                              Static Pages
-                            </Link>
-                            <Link
-                              to="/admin/footer"
-                              className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                              onClick={() => setShowUserMenu(false)}
-                            >
-                              <Edit3 className="w-4 h-4 mr-2" />
-                              Footer Editor
-                            </Link>
-                            <Link
-                              to="/admin/featured-settings"
-                              className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                              onClick={() => setShowUserMenu(false)}
-                            >
-                              <Star className="w-4 h-4 mr-2" />
-                              Featured Settings
-                            </Link>
-                            <Link
-                              to="/internal-analytics"
-                              className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                              onClick={() => setShowUserMenu(false)}
-                            >
-                              <BarChart3 className="w-4 h-4 mr-2" />
-                              Analytics
-                            </Link>
-                          </>
-                        )}
-                        <button
-                          onClick={handleSignOut}
-                          className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 text-left"
-                        >
-                          <LogOut className="w-4 h-4 mr-2" />
-                          Sign Out
-                        </button>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <Link
-                  to="/auth"
-                  className="bg-brand-700 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-brand-800 transition-colors"
-                >
-                  Sign In
-                </Link>
-              )}
-            </div>
-
-            {/* Mobile menu button */}
-            <div className="md:hidden flex items-center">
-              <button
-                onClick={() => setIsMobileMenuOpen(true)}
-                className="p-2 text-white hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-white/40"
-              >
-                <Menu className="w-6 h-6" />
-              </button>
-            </div>
-          </div>
         </div>
-      </header>
 
-      {/* Mobile Sidebar */}
-      {isMobileMenuOpen && (
-        <>
-          {/* Overlay */}
-          <div
-            className="fixed inset-0 bg-black bg-opacity-50 z-40 md:hidden"
-            onClick={() => setIsMobileMenuOpen(false)}
-          />
-
-          {/* Sidebar */}
-          <div className="fixed top-0 right-0 h-full w-80 bg-white shadow-xl z-50 md:hidden transform transition-transform duration-300 ease-in-out">
-            <div className="flex flex-col h-full">
-              {/* Header */}
-              <div className="flex items-center justify-between p-4 border-b border-gray-200">
-                <div className="flex items-center">
-                  <div className="text-brand-700">
-                    <Logo />
-                  </div>
-                </div>
-                <button
-                  onClick={() => setIsMobileMenuOpen(false)}
-                  className="text-gray-400 hover:text-gray-600 transition-colors p-1"
-                >
-                  <X className="w-6 h-6" />
-                </button>
-              </div>
-
-              {/* Navigation */}
-              <div className="flex-1 overflow-y-auto">
-                <nav className="p-4 space-y-2">
-                  <Link
-                    to="/"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                    className={`flex items-center px-4 py-3 text-base font-medium rounded-md transition-colors ${
-                      location.pathname === "/"
-                        ? "text-brand-700 bg-gray-100"
-                        : "text-gray-600 hover:text-brand-700 hover:bg-gray-50"
-                    }`}
-                  >
-                    <Home className="w-5 h-5 mr-3" />
-                    Home
-                  </Link>
-                  <Link
-                    to="/browse"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                    className={`flex items-center px-4 py-3 text-base font-medium rounded-md transition-colors ${
-                      location.pathname === "/browse"
-                        ? "text-brand-700 bg-gray-100"
-                        : "text-gray-600 hover:text-brand-700 hover:bg-gray-50"
-                    }`}
-                  >
-                    <Search className="w-5 h-5 mr-3" />
-                    Browse Listings
-                  </Link>
-                  <Link
-                    to="/post"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                    className={`flex items-center px-4 py-3 text-base font-medium rounded-md transition-colors ${
-                      location.pathname === "/post"
-                        ? "text-brand-700 bg-gray-100"
-                        : "text-gray-600 hover:text-brand-700 hover:bg-gray-50"
-                    }`}
-                  >
-                    <Plus className="w-5 h-5 mr-3" />
-                    Post Listing
-                  </Link>
-
-                  {user && (
-                    <>
-                      <div className="border-t border-gray-200 my-4"></div>
-                      <div className="px-4 py-2">
-                        <div className="text-sm font-medium text-gray-900">
-                          {profile?.full_name
-                            ? capitalizeName(profile.full_name)
-                            : ""}
-                        </div>
-                        <div className="text-sm text-gray-500">
-                          {profile?.role === "agent" && profile?.agency && (
-                            <span className="block">{profile.agency}</span>
-                          )}
-                          <span className="capitalize">{profile?.role}</span>
-                        </div>
-                      </div>
-
-                      <Link
-                        to="/account-settings"
-                        onClick={() => setIsMobileMenuOpen(false)}
-                        className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                      >
-                        <User className="w-5 h-5 mr-3" />
-                        Account Settings
-                      </Link>
-                      
-                      {/* My Agency Page - only for agents with agency */}
-                      {profile?.role === 'agent' && profile?.agency && (
-                        <Link
-                          to={`/agencies/${agencyNameToSlug(profile.agency)}`}
-                          onClick={() => setIsMobileMenuOpen(false)}
-                          className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                        >
-                          <Building2 className="w-5 h-5 mr-3" />
-                          My Agency Page
-                        </Link>
-                      )}
-                      
-                      <Link
-                        to="/dashboard"
-                        onClick={() => setIsMobileMenuOpen(false)}
-                        className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                      >
-                        <LayoutDashboard className="w-5 h-5 mr-3" />
-                        My Dashboard
-                      </Link>
-                      <Link
-                        to="/favorites"
-                        onClick={() => setIsMobileMenuOpen(false)}
-                        className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                      >
-                        <Heart className="w-5 h-5 mr-3" />
-                        My Favorites
-                      </Link>
-
-                      {!loading && profile?.is_admin && (
-                        <>
-                          <div className="border-t border-gray-200 my-4"></div>
-                          <div className="px-4 py-2">
-                            <div className="text-sm font-medium text-gray-500 uppercase tracking-wider">
-                              Admin
-                            </div>
-                          </div>
-                          <Link
-                            to="/admin"
-                            onClick={() => setIsMobileMenuOpen(false)}
-                            className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                          >
-                            <Settings className="w-5 h-5 mr-3" />
-                            Admin Panel
-                          </Link>
-                          <Link
-                            to="/admin/static-pages"
-                            onClick={() => setIsMobileMenuOpen(false)}
-                            className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                          >
-                            <FileText className="w-5 h-5 mr-3" />
-                            Static Pages
-                          </Link>
-                          <Link
-                            to="/admin/footer"
-                            onClick={() => setIsMobileMenuOpen(false)}
-                            className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                          >
-                            <Edit3 className="w-5 h-5 mr-3" />
-                            Footer Editor
-                          </Link>
-                          <Link
-                            to="/admin/featured-settings"
-                            onClick={() => setIsMobileMenuOpen(false)}
-                            className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                          >
-                            <Star className="w-5 h-5 mr-3" />
-                            Featured Settings
-                          </Link>
-                          <Link
-                            to="/internal-analytics"
-                            onClick={() => setIsMobileMenuOpen(false)}
-                            className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                          >
-                            <BarChart3 className="w-5 h-5 mr-3" />
-                            Analytics
-                          </Link>
-                          <Link
-                            to="/internal-analytics"
-                            onClick={() => setIsMobileMenuOpen(false)}
-                            className="flex items-center px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors"
-                          >
-                            <BarChart3 className="w-5 h-5 mr-3" />
-                            Analytics
-                          </Link>
-                        </>
-                      )}
-
-                      <div className="border-t border-gray-200 my-4"></div>
-                      <button
-                        onClick={handleSignOut}
-                        className="flex items-center w-full px-4 py-3 text-base font-medium text-gray-600 hover:text-[#273140] hover:bg-gray-50 rounded-md transition-colors text-left"
-                      >
-                        <LogOut className="w-5 h-5 mr-3" />
-                        Sign Out
-                      </button>
-                    </>
-                  )}
-
-                  {!user && (
-                    <>
-                      <div className="border-t border-gray-200 my-4"></div>
-                      <Link
-                        to="/auth"
-                        onClick={() => setIsMobileMenuOpen(false)}
-                        className="flex items-center px-4 py-3 text-base font-medium bg-[#273140] text-white rounded-md hover:bg-[#1e252f] transition-colors"
-                      >
-                        <User className="w-5 h-5 mr-3" />
-                        Sign In
-                      </Link>
-                    </>
-                  )}
-                </nav>
-              </div>
-            </div>
-          </div>
-        </>
-      )}
-
-      {/* Sign Out Success Message */}
-      {showSignOutMessage && (
-        <div className="fixed top-20 right-4 bg-green-500 text-white px-4 py-2 rounded-md shadow-lg z-50 animate-fade-in">
-          Successfully signed out!
-        </div>
-      )}
-
-      <main className="flex-1">
         {loading ? (
-          <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-            <div className="text-center">
-              <div className="flex items-center justify-center mb-4">
-                <div className="text-brand-700">
-                  <Logo />
-                </div>
-              </div>
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-brand-700 mx-auto"></div>
-              <p className="text-gray-600 mt-4">Loading...</p>
+          <div className="text-center py-8">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#273140] mx-auto"></div>
+            <p className="text-gray-600 mt-4">Loading your listings...</p>
+          </div>
+        ) : listings.length === 0 ? (
+          <div className="text-center py-12 bg-white rounded-lg shadow-sm border border-gray-200">
+            <div className="text-gray-400 mb-4">
+              <svg
+                className="mx-auto h-12 w-12"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+                />
+              </svg>
             </div>
+            <h3 className="text-lg font-medium text-gray-900 mb-2">
+              No listings yet
+            </h3>
+            <p className="text-gray-500 mb-4">
+              Start by creating your first property listing.
+            </p>
+            <Link
+              to="/post"
+              className="inline-flex items-center bg-accent-500 text-white px-4 py-2 rounded-md font-medium hover:bg-accent-600 transition-colors"
+            >
+              <Plus className="w-4 h-4 mr-2" />
+              Create Listing
+            </Link>
           </div>
         ) : (
-          children
-        )}
-      </main>
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+            <div className="overflow-x-auto min-w-full">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider min-w-0 w-1/4">
+                      Property
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-24">
+                      Price
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-20">
+                      Views
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-32">
+                      Status
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-40">
+                      Created
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-48">
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {listings.map((listing) => {
+                    const featuredImage =
+                      listing.listing_images?.find((img) => img.is_featured) ||
+                      listing.listing_images?.[0];
 
-      <Footer />
+                    return (
+                      <tr key={listing.id} className="hover:bg-gray-50">
+                        <td className="px-6 py-4">
+                          <div className="flex items-center">
+                            {featuredImage && (
+                              <img
+                                src={featuredImage.image_url}
+                                alt={listing.title}
+                                className="w-12 h-12 object-cover rounded-lg mr-4"
+                              />
+                            )}
+                            <div className="min-w-0 flex-1">
+                              <Link
+                                to={`/listing/${listing.id}`}
+                                className="font-medium text-gray-900 hover:text-[#4E4B43] transition-colors block truncate"
+                              >
+                                {listing.title}
+                              </Link>
+                              <div className="text-sm text-gray-500 truncate">
+                                {listing.bedrooms} bed, {listing.bathrooms} bath
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                          {listing.call_for_price
+                            ? 'Call for Price'
+                            : `${formatPrice(listing.price)}/month`}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-center">
+                          <div className="flex items-center text-sm text-gray-900">
+                            <Eye className="w-4 h-4 mr-1 text-gray-400" />
+                            {listing.views || 0}
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <div className="flex items-center space-x-2">
+                            <span
+                              className={`px-2 py-1 text-xs rounded-full ${
+                                listing.is_active
+                                  ? "bg-green-100 text-green-800"
+                                  : "bg-red-100 text-red-800"
+                              }`}
+                            >
+                              {listing.is_active ? "Active" : "Inactive"}
+                            </span>
+                            {!listing.approved && (
+                              <span className="px-2 py-1 text-xs bg-yellow-100 text-yellow-800 rounded-full">
+                                Pending Approval
+                              </span>
+                            )}
+                            {isListingCurrentlyFeatured(listing) && (
+                              <span className="px-2 py-1 text-xs bg-accent-500 text-white rounded-full flex items-center">
+                                <Star className="w-3 h-3 mr-1" />
+                                Featured
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                          <div>
+                            <div className="whitespace-nowrap">
+                              Posted:{" "}
+                              {new Date(
+                                listing.created_at,
+                              ).toLocaleDateString()}
+                            </div>
+                            {listing.last_published_at && (
+                              <div className="text-xs text-gray-400 whitespace-nowrap">
+                                Last Published:{" "}
+                                {new Date(
+                                  listing.last_published_at,
+                                ).toLocaleDateString()}
+                              </div>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                          <div className="flex items-center space-x-3">
+                            <Link
+                              to={`/listing/${listing.id}`}
+                              title="View Listing"
+                              className="text-[#273140] hover:text-[#1e252f] transition-colors flex-shrink-0"
+                            >
+                              <Eye className="w-5 h-5" />
+                            </Link>
+
+                            <Link
+                              to={`/edit/${listing.id}`}
+                              className="flex items-center space-x-1 px-2 py-1 text-blue-600 hover:text-blue-800 transition-colors flex-shrink-0"
+                              title="Edit Listing"
+                            >
+                              <Edit className="w-4 h-4" />
+                              <span className="text-sm hidden sm:inline">
+                                Edit
+                              </span>
+                            </Link>
+
+                            <button
+                              type="button"
+                              onClick={() =>
+                                handleToggleFeature(
+                                  listing.id,
+                                  isListingCurrentlyFeatured(listing),
+                                )
+                              }
+                              disabled={
+                                actionLoading === listing.id ||
+                                (!isListingCurrentlyFeatured(listing) &&
+                                  (!canFeatureMore || globalLimitReached))
+                              }
+                              className={`transition-colors flex-shrink-0 ${
+                                isListingCurrentlyFeatured(listing)
+                                  ? "text-accent-600 hover:text-accent-600"
+                                  : !canFeatureMore || globalLimitReached
+                                    ? "text-gray-300 cursor-not-allowed"
+                                    : "text-gray-400 hover:text-accent-600"
+                              }`}
+                              title={
+                                isListingCurrentlyFeatured(listing)
+                                  ? "Remove Featured"
+                                  : globalLimitReached
+                                    ? "The sitewide maximum for featured listings has been reached"
+                                    : !canFeatureMore
+                                      ? `You have reached your featured listing limit (${currentUserFeaturedCount}/${effectiveUserFeaturedLimit})`
+                                      : "Make Featured"
+                              }
+                            >
+                              <Star
+                                className={`w-5 h-5 ${isListingCurrentlyFeatured(listing) ? "fill-current" : ""}`}
+                              />
+                            </button>
+
+                            {listing.is_active ? (
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  handleUnpublishListing(listing.id)
+                                }
+                                disabled={
+                                  actionLoading === listing.id ||
+                                  !listing.approved
+                                }
+                                className="text-orange-600 hover:text-orange-800 transition-colors flex-shrink-0"
+                                title="Unpublish Listing"
+                              >
+                                <EyeOff className="w-5 h-5" />
+                              </button>
+                            ) : (
+                              <button
+                                type="button"
+                                onClick={() => handleRenewListing(listing.id)}
+                                disabled={
+                                  actionLoading === listing.id ||
+                                  !listing.approved
+                                }
+                                className="text-blue-600 hover:text-blue-800 transition-colors flex-shrink-0"
+                                title="Republish Listing"
+                              >
+                                <RefreshCw className="w-5 h-5" />
+                              </button>
+                            )}
+                            <button
+                              type="button"
+                              onClick={() => handleDeleteListing(listing.id)}
+                              disabled={actionLoading === listing.id}
+                              className="text-red-600 hover:text-red-800 transition-colors flex-shrink-0"
+                              title="Delete Listing"
+                            >
+                              <Trash2 className="w-5 h-5" />
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
+
+export { Dashboard };

--- a/src/services/agencies.ts
+++ b/src/services/agencies.ts
@@ -1,0 +1,198 @@
+import { supabase, Agency } from "../config/supabase";
+import { agencyNameToSlug } from "../utils/agency";
+import { sanitizeHtml } from "../utils/sanitize";
+
+export interface AgencyCreateInput {
+  name: string;
+  slug: string;
+  logo_url?: string | null;
+  banner_url?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  website?: string | null;
+  about_html?: string | null;
+}
+
+export interface AgencyUpdateInput {
+  name?: string;
+  logo_url?: string | null;
+  banner_url?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  website?: string | null;
+  about_html?: string | null;
+}
+
+function normalizeOptionalString(value?: string | null) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function prepareAboutHtml(value?: string | null) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  const textContent = value
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .trim();
+
+  if (!textContent) {
+    return null;
+  }
+
+  return sanitizeHtml(value);
+}
+
+function mapAgencyRow(row: Agency | null): Agency | null {
+  if (!row) {
+    return null;
+  }
+
+  const sanitizedAbout = prepareAboutHtml(row.about_html ?? undefined);
+
+  return {
+    ...row,
+    about_html: sanitizedAbout === undefined ? row.about_html ?? null : sanitizedAbout,
+  };
+}
+
+export const agenciesService = {
+  async getAgencyBySlug(slug: string): Promise<Agency | null> {
+    const normalizedSlug = agencyNameToSlug(slug);
+
+    if (!normalizedSlug) {
+      return null;
+    }
+
+    const { data, error } = await supabase
+      .from("agencies")
+      .select("*")
+      .eq("slug", normalizedSlug)
+      .maybeSingle<Agency>();
+
+    if (error) {
+      console.error("[svc] getAgencyBySlug error", error);
+      throw error;
+    }
+
+    return mapAgencyRow(data);
+  },
+
+  async createAgency(payload: AgencyCreateInput): Promise<Agency | null> {
+    const normalizedName = payload.name?.trim();
+    const normalizedSlug = agencyNameToSlug(payload.slug || payload.name);
+
+    if (!normalizedName || !normalizedSlug) {
+      throw new Error("Agency name and slug are required");
+    }
+
+    const insertPayload = {
+      name: normalizedName,
+      slug: normalizedSlug,
+      logo_url: normalizeOptionalString(payload.logo_url),
+      banner_url: normalizeOptionalString(payload.banner_url),
+      phone: normalizeOptionalString(payload.phone),
+      email: normalizeOptionalString(payload.email),
+      website: normalizeOptionalString(payload.website),
+      about_html: prepareAboutHtml(payload.about_html) ?? null,
+    };
+
+    const { data, error } = await supabase
+      .from("agencies")
+      .insert(insertPayload)
+      .select("*")
+      .maybeSingle<Agency>();
+
+    if (error) {
+      console.error("[svc] createAgency error", error);
+      throw error;
+    }
+
+    return mapAgencyRow(data ?? null);
+  },
+
+  async updateAgencyById(id: string, payload: AgencyUpdateInput): Promise<Agency | null> {
+    const updates: Record<string, any> = {};
+
+    if (payload.name !== undefined) {
+      const normalizedName = payload.name.trim();
+      if (!normalizedName) {
+        throw new Error("Agency name cannot be empty");
+      }
+      updates.name = normalizedName;
+    }
+
+    const normalizedLogo = normalizeOptionalString(payload.logo_url);
+    if (normalizedLogo !== undefined) {
+      updates.logo_url = normalizedLogo;
+    }
+
+    const normalizedBanner = normalizeOptionalString(payload.banner_url);
+    if (normalizedBanner !== undefined) {
+      updates.banner_url = normalizedBanner;
+    }
+
+    const normalizedPhone = normalizeOptionalString(payload.phone);
+    if (normalizedPhone !== undefined) {
+      updates.phone = normalizedPhone;
+    }
+
+    const normalizedEmail = normalizeOptionalString(payload.email);
+    if (normalizedEmail !== undefined) {
+      updates.email = normalizedEmail;
+    }
+
+    const normalizedWebsite = normalizeOptionalString(payload.website);
+    if (normalizedWebsite !== undefined) {
+      updates.website = normalizedWebsite;
+    }
+
+    const aboutHtml = prepareAboutHtml(payload.about_html);
+    if (aboutHtml !== undefined) {
+      updates.about_html = aboutHtml;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      const { data, error } = await supabase
+        .from("agencies")
+        .select("*")
+        .eq("id", id)
+        .maybeSingle<Agency>();
+
+      if (error) {
+        console.error("[svc] updateAgencyById fetch error", error);
+        throw error;
+      }
+
+      return mapAgencyRow(data ?? null);
+    }
+
+    const { data, error } = await supabase
+      .from("agencies")
+      .update(updates)
+      .eq("id", id)
+      .select("*")
+      .maybeSingle<Agency>();
+
+    if (error) {
+      console.error("[svc] updateAgencyById error", error);
+      throw error;
+    }
+
+    return mapAgencyRow(data ?? null);
+  },
+};

--- a/src/services/profiles.ts
+++ b/src/services/profiles.ts
@@ -5,7 +5,7 @@ export const profilesService = {
   async getProfile(userId: string): Promise<Profile | null> {
     const { data, error } = await supabase
       .from('profiles')
-      .select('id, full_name, role, phone, agency, is_admin, created_at, updated_at, is_banned, email, can_feature_listings, max_featured_listings_per_user')
+      .select('id, full_name, role, phone, agency, is_admin, created_at, updated_at, is_banned, email, can_feature_listings, max_featured_listings_per_user, can_manage_agency')
       .eq('id', userId)
       .single();
 
@@ -22,7 +22,7 @@ export const profilesService = {
       .from('profiles')
       .update(updates)
       .eq('id', userId)
-      .select('id, full_name, role, phone, agency, is_admin, created_at, updated_at, is_banned, email, can_feature_listings, max_featured_listings_per_user')
+      .select('id, full_name, role, phone, agency, is_admin, created_at, updated_at, is_banned, email, can_feature_listings, max_featured_listings_per_user, can_manage_agency')
       .single();
 
     if (error) {
@@ -36,7 +36,7 @@ export const profilesService = {
   async getAllProfiles(): Promise<Profile[]> {
     const { data, error } = await supabase
       .from('profiles')
-      .select('id, full_name, role, phone, agency, is_admin, created_at, updated_at, is_banned, email, can_feature_listings, max_featured_listings_per_user')
+      .select('id, full_name, role, phone, agency, is_admin, created_at, updated_at, is_banned, email, can_feature_listings, max_featured_listings_per_user, can_manage_agency')
       .order('created_at', { ascending: false });
 
     if (error) {

--- a/src/utils/agency.ts
+++ b/src/utils/agency.ts
@@ -1,0 +1,35 @@
+export function agencyNameToSlug(name: string): string {
+  if (!name) {
+    return '';
+  }
+
+  const normalized = name
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+
+  return normalized
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function slugToAgencyLabel(slug: string): string {
+  if (!slug) {
+    return '';
+  }
+
+  const cleaned = slug
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!cleaned) {
+    return '';
+  }
+
+  return cleaned
+    .split(' ')
+    .map(part => (part ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ');
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,8 @@
+export function normalizeUrlForHref(input?: string): string {
+  if (!input) return "";
+  const trimmed = input.trim();
+  if (/^(https?:\/\/|mailto:|tel:)/i.test(trimmed)) {
+    return trimmed;
+  }
+  return `https://${trimmed}`;
+}


### PR DESCRIPTION
## Summary
- reorganized the agency page layout with a sticky desktop filter sidebar, a consolidated branding/info card, and listings presented directly beneath it
- added copy-link toast handling and inline share controls while wiring website links through a shared href normalizer
- created a normalizeUrlForHref helper to support lenient external URLs for agency contact information

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8b126f7308329b2bed59ee02c5734