### PR TITLE
Add listing metrics view and expose in dashboard

### DIFF
--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -56,6 +56,9 @@ export interface Listing {
   featured_until?: string;
   is_active: boolean;
   views: number;
+  posted_at?: string | null;
+  impressions?: number;
+  direct_views?: number;
   created_at: string;
   updated_at: string;
   last_published_at: string;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import {
   Edit,
   Eye,
+  MousePointerClick,
   Star,
   Trash2,
   RefreshCw,
@@ -406,8 +407,11 @@ export default function Dashboard() {
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-24">
                       Price
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-20">
-                      Views
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-24">
+                      Impressions
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-24">
+                      Direct Views
                     </th>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-32">
                       Status
@@ -455,10 +459,16 @@ export default function Dashboard() {
                             ? 'Call for Price'
                             : `${formatPrice(listing.price)}/month`}
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-center">
-                          <div className="flex items-center text-sm text-gray-900">
-                            <Eye className="w-4 h-4 mr-1 text-gray-400" />
-                            {listing.views || 0}
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                          <div className="flex items-center gap-1.5">
+                            <Eye className="h-4 w-4 opacity-70" aria-hidden />
+                            <span>{listing.impressions ?? 0}</span>
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                          <div className="flex items-center gap-1.5">
+                            <MousePointerClick className="h-4 w-4 opacity-70" aria-hidden />
+                            <span>{listing.direct_views ?? 0}</span>
                           </div>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap">

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -106,6 +106,22 @@ export function ListingDetail() {
     return sqft.toLocaleString();
   };
 
+  const formatPostedDate = (value?: string | null): string | null => {
+    if (!value) {
+      return null;
+    }
+
+    const date = typeof value === 'string' ? new Date(value) : value;
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    const year = date.getFullYear();
+    return `${month}/${day}/${year}`;
+  };
+
   useEffect(() => {
     if (id && !authLoading) {
       loadListing();
@@ -188,6 +204,8 @@ export function ListingDetail() {
       setLoading(false);
     }
   };
+
+  const postedDateText = formatPostedDate(listing?.posted_at ?? listing?.created_at ?? null);
 
   const handleFavoriteToggle = async () => {
     if (!user || !listing) {
@@ -358,6 +376,9 @@ export function ListingDetail() {
             <h1 className="text-2xl md:text-[1.65rem] font-semibold text-[#273140] mb-2">
               {listing.title}
             </h1>
+            {postedDateText && (
+              <p className="text-xs text-muted-foreground mt-1">Posted: {postedDateText}</p>
+            )}
           </section>
 
           {/* Location + Tag (mobile-safe truncation) */}

--- a/src/services/listings.ts
+++ b/src/services/listings.ts
@@ -858,13 +858,22 @@ export const listingsService = {
         approved,
         is_active,
         owner:profiles!listings_user_id_fkey(full_name, role, agency),
-        listing_images(id, image_url, is_featured, sort_order)
+        listing_images(id, image_url, is_featured, sort_order),
+        metrics:listing_metrics_v1!left(listing_id, impressions, direct_views)
       `)
       .eq('user_id', userId)
       .order('created_at', { ascending: false });
 
     if (error) throw error;
-    return data as Listing[];
+    return (data ?? []).map((listing: any) => {
+      const { metrics, ...rest } = listing;
+
+      return {
+        ...rest,
+        impressions: metrics?.impressions ?? 0,
+        direct_views: metrics?.direct_views ?? 0,
+      } as Listing;
+    });
   },
 
   async incrementListingView(listingId: string) {

--- a/supabase/migrations/20250914120000_listings_metrics_view.sql
+++ b/supabase/migrations/20250914120000_listings_metrics_view.sql
@@ -1,0 +1,59 @@
+/*
+  # Listing metrics view
+
+  - Aggregates impressions and direct views for each listing based on analytics events
+  - Counts impression events from both single listing events and batched payloads
+  - Counts direct views from listing view/page view events
+  - Exposes a simple view that can be joined from Supabase client code
+*/
+
+CREATE OR REPLACE VIEW public.listing_metrics_v1 AS
+WITH raw_impressions AS (
+  SELECT
+    (ae.props ->> 'listing_id')::uuid AS listing_id
+  FROM public.analytics_events ae
+  WHERE ae.event_name IN ('listing_impression', 'listing_card_view')
+    AND ae.props ? 'listing_id'
+    AND (ae.props ->> 'listing_id') ~* '^[0-9a-f-]{8}-[0-9a-f-]{4}-[0-9a-f-]{4}-[0-9a-f-]{4}-[0-9a-f-]{12}$'
+  UNION ALL
+  SELECT
+    CASE
+      WHEN expanded.listing_id_text ~* '^[0-9a-f-]{8}-[0-9a-f-]{4}-[0-9a-f-]{4}-[0-9a-f-]{4}-[0-9a-f-]{12}$'
+      THEN expanded.listing_id_text::uuid
+      ELSE NULL
+    END AS listing_id
+  FROM public.analytics_events ae
+  CROSS JOIN LATERAL (
+    SELECT jsonb_array_elements_text(
+      COALESCE(ae.props -> 'listing_ids', ae.props -> 'ids', '[]'::jsonb)
+    ) AS listing_id_text
+  ) AS expanded
+  WHERE ae.event_name IN ('listing_impression_batch', 'listing_card_view_batch')
+),
+rollup_impressions AS (
+  SELECT
+    ri.listing_id,
+    COUNT(*)::bigint AS impressions
+  FROM raw_impressions ri
+  WHERE ri.listing_id IS NOT NULL
+  GROUP BY ri.listing_id
+),
+rollup_views AS (
+  SELECT
+    (ae.props ->> 'listing_id')::uuid AS listing_id,
+    COUNT(*)::bigint AS direct_views
+  FROM public.analytics_events ae
+  WHERE ae.event_name IN ('listing_view', 'listing_page_view')
+    AND ae.props ? 'listing_id'
+    AND (ae.props ->> 'listing_id') ~* '^[0-9a-f-]{8}-[0-9a-f-]{4}-[0-9a-f-]{4}-[0-9a-f-]{4}-[0-9a-f-]{12}$'
+  GROUP BY 1
+)
+SELECT
+  l.id AS listing_id,
+  COALESCE(i.impressions, 0)::bigint AS impressions,
+  COALESCE(v.direct_views, 0)::bigint AS direct_views
+FROM public.listings l
+LEFT JOIN rollup_impressions i ON i.listing_id = l.id
+LEFT JOIN rollup_views v ON v.listing_id = l.id;
+
+GRANT SELECT ON public.listing_metrics_v1 TO anon, authenticated;


### PR DESCRIPTION
## Summary
- add a Supabase view that rolls up listing impressions and direct views from analytics events
- update listing fetching to include metrics and show them in the dashboard with new icons
- display a subtle posted date on the listing detail page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb6d6bf5c083299724f104fd1fdf3a