### PR TITLE
Implement batched analytics pipeline

### DIFF
--- a/src/components/shared/Layout.tsx
+++ b/src/components/shared/Layout.tsx
@@ -19,8 +19,7 @@ import {
   Paintbrush,
 } from "lucide-react";
 import { useAuth, AUTH_CONTEXT_ID } from "@/hooks/useAuth";
-import { usePageTracking } from "../../hooks/usePageTracking";
-import { useAnalyticsAuth } from "../../lib/analytics";
+import { useAnalyticsInit } from "@/hooks/useAnalyticsInit";
 import { Footer } from "./Footer";
 import { capitalizeName } from "../../utils/formatters";
 import { supabase, type Agency } from "@/config/supabase";
@@ -39,8 +38,7 @@ export function Layout({ children }: LayoutProps) {
   const { user, profile, signOut, loading, authContextId } = useAuth();
   
   // Initialize analytics tracking
-  usePageTracking();
-  useAnalyticsAuth();
+  useAnalyticsInit();
   
   const navigate = useNavigate();
   const location = useLocation();

--- a/src/hooks/useAnalyticsInit.ts
+++ b/src/hooks/useAnalyticsInit.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+import { supabase } from '@/config/supabase';
+import { initAnalytics, setUserId, track } from '@/lib/analytics';
+import { useAuth } from './useAuth';
+
+export function useAnalyticsInit(): void {
+  const location = useLocation();
+  const previousPathname = useRef<string | null>(null);
+  const { user } = useAuth();
+
+  useEffect(() => {
+    initAnalytics(supabase);
+  }, []);
+
+  useEffect(() => {
+    setUserId(user?.id ?? null);
+  }, [user?.id]);
+
+  useEffect(() => {
+    const pathname = location.pathname;
+    if (previousPathname.current === pathname) {
+      return;
+    }
+    previousPathname.current = pathname;
+    track('page_view', { path: pathname });
+  }, [location.pathname]);
+}

--- a/src/lib/analytics.types.ts
+++ b/src/lib/analytics.types.ts
@@ -1,0 +1,24 @@
+export type AnalyticsEventName =
+  | 'session_start'
+  | 'session_end'
+  | 'page_view'
+  | 'listing_view'
+  | 'listing_impression_batch'
+  | 'filter_apply'
+  | 'search_query'
+  | 'agency_page_view'
+  | 'agency_filter_apply'
+  | 'agency_share'
+  | 'post_started'
+  | 'post_submitted'
+  | 'post_success'
+  | 'post_abandoned';
+
+export interface AnalyticsEventPayload {
+  session_id: string;
+  anon_id: string;
+  user_id: string | null;
+  event_name: AnalyticsEventName;
+  event_props: Record<string, unknown>;
+  occurred_at: string;
+}

--- a/src/pages/InternalAnalytics.tsx
+++ b/src/pages/InternalAnalytics.tsx
@@ -141,7 +141,7 @@ export function InternalAnalytics() {
       try {
         // today only
         const [kpisArr, funnelArr] = await Promise.all([
-          rpc<KpisRow[]>('analytics_kpis', { days_back: 0 }),
+          rpc<KpisRow[]>('analytics_kpis', { days_back: 0, tz: 'America/New_York' }),
           rpc<SummaryRow[]>('analytics_summary', { days_back: 0 }),
         ]);
 


### PR DESCRIPTION
## Summary
- replace the client analytics singleton with session-aware identity, idle handling, and a batched queue that flushes to the track function
- add a dedicated analytics init hook that wires Supabase, user identity, and SPA page views plus expose shared event name types
- rewrite the Supabase Edge Function track handler to accept event batches, enrich with user agent/IP hash, and touch/close sessions, and update the dashboard KPI RPC invocation to include the target timezone

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0925662b08329aa78f1fc833ddf91