### PR TITLE
Login-gate modal: open in signup, friendlier-but-required copy, tighter layout

### DIFF
--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -381,7 +381,7 @@ export function AuthForm({
               </div>
             </form>
           ) : (
-            <form className="space-y-6" onSubmit={handleSubmit}>
+            <form className={compact ? "space-y-3" : "space-y-6"} onSubmit={handleSubmit}>
               {error && (
                 <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-md text-sm">
                   {error}
@@ -616,7 +616,7 @@ export function AuthForm({
           )}
 
           {!showForgotPassword && (
-            <div className="mt-6">
+            <div className={compact ? "mt-3" : "mt-6"}>
               {!isSignUp && (
                 <div className="text-center mb-4">
                   <button

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -20,11 +20,25 @@ interface AuthFormProps {
   // When true, render without the full-page chrome (gray bg, page heading,
   // inner shadow card). Use this when AuthForm is embedded inside a modal.
   compact?: boolean;
+  // Which view to open in by default. When omitted, falls back to the
+  // existing location.state-based behavior so non-modal call sites are
+  // unchanged. The user can always toggle between modes from inside the
+  // form via the "Don't have an account? Sign up" / "Already have an
+  // account? Sign in" buttons.
+  initialMode?: "signin" | "signup";
 }
 
-export function AuthForm({ onAuthSuccess, compact = false }: AuthFormProps = {}) {
+export function AuthForm({
+  onAuthSuccess,
+  compact = false,
+  initialMode,
+}: AuthFormProps = {}) {
   const location = useLocation();
-  const [isSignUp, setIsSignUp] = useState(location.state?.isSignUp || false);
+  const [isSignUp, setIsSignUp] = useState(
+    initialMode !== undefined
+      ? initialMode === "signup"
+      : location.state?.isSignUp || false,
+  );
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);

--- a/src/pages/CommercialListingDetail.tsx
+++ b/src/pages/CommercialListingDetail.tsx
@@ -1331,16 +1331,20 @@ export function CommercialListingDetail() {
       <Modal
         isOpen={authModalOpen}
         onClose={handleAuthModalClose}
-        title="Sign in to continue"
+        title="Create a free account"
         size="md"
       >
         <div className="space-y-3">
           <p className="text-sm text-gray-500">
             {authModalAction === 'reveal_phone'
-              ? "We'll show the phone number as soon as you're signed in."
-              : "We'll send your callback request as soon as you're signed in."}
+              ? "Takes a few seconds. We'll show the phone number right after."
+              : "Takes a few seconds. We'll send your request right after."}
           </p>
-          <AuthForm onAuthSuccess={handleAuthSuccessFromModal} compact />
+          <AuthForm
+            onAuthSuccess={handleAuthSuccessFromModal}
+            compact
+            initialMode="signup"
+          />
         </div>
       </Modal>
     </div>

--- a/src/pages/CommercialListingDetail.tsx
+++ b/src/pages/CommercialListingDetail.tsx
@@ -1331,14 +1331,14 @@ export function CommercialListingDetail() {
       <Modal
         isOpen={authModalOpen}
         onClose={handleAuthModalClose}
-        title="Create a free account"
+        title="Create a free account to continue"
         size="md"
       >
         <div className="space-y-3">
           <p className="text-sm text-gray-500">
             {authModalAction === 'reveal_phone'
-              ? "Takes a few seconds. We'll show the phone number right after."
-              : "Takes a few seconds. We'll send your request right after."}
+              ? "An account is required to view contact info. It's free and takes just a few seconds — we'll show the phone right after."
+              : "An account is required to send a request. It's free and takes just a few seconds — we'll send your message right after."}
           </p>
           <AuthForm
             onAuthSuccess={handleAuthSuccessFromModal}

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -1506,14 +1506,14 @@ export function ListingDetail() {
       <Modal
         isOpen={authModalOpen}
         onClose={handleAuthModalClose}
-        title="Create a free account"
+        title="Create a free account to continue"
         size="md"
       >
         <div className="space-y-3">
           <p className="text-sm text-gray-500">
             {authModalAction === "reveal_phone"
-              ? "Takes a few seconds. We'll show the phone number right after."
-              : "Takes a few seconds. We'll send your request right after."}
+              ? "An account is required to view contact info. It's free and takes just a few seconds — we'll show the phone right after."
+              : "An account is required to send a request. It's free and takes just a few seconds — we'll send your message right after."}
           </p>
           <AuthForm
             onAuthSuccess={handleAuthSuccessFromModal}

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -1506,16 +1506,20 @@ export function ListingDetail() {
       <Modal
         isOpen={authModalOpen}
         onClose={handleAuthModalClose}
-        title="Sign in to continue"
+        title="Create a free account"
         size="md"
       >
         <div className="space-y-3">
           <p className="text-sm text-gray-500">
             {authModalAction === "reveal_phone"
-              ? "We'll show the phone number as soon as you're signed in."
-              : "We'll send your callback request as soon as you're signed in."}
+              ? "Takes a few seconds. We'll show the phone number right after."
+              : "Takes a few seconds. We'll send your request right after."}
           </p>
-          <AuthForm onAuthSuccess={handleAuthSuccessFromModal} compact />
+          <AuthForm
+            onAuthSuccess={handleAuthSuccessFromModal}
+            compact
+            initialMode="signup"
+          />
         </div>
       </Modal>
     </div>


### PR DESCRIPTION
## Summary
- Auth modal on listing detail now opens directly to the **signup** view (was signin), since most logged-out clickers don't have an account.
- Copy reframed to make the requirement explicit while staying friendly: title "Create a free account to continue" + sublines that lead with "An account is required..." and immediately soften with the free / few-seconds / auto-continue reassurance.
- Compact-mode AuthForm spacing tightened (space-y-6 → space-y-3, footer mt-6 → mt-3) so the modal isn't unnecessarily tall.

## Test plan
- [ ] Logged out → click eye icon on a rental listing → modal opens to signup, copy reads "Create a free account to continue" / "An account is required to view contact info..."
- [ ] Same flow on commercial listing
- [ ] Signup completes → phone reveals automatically
- [ ] Fill callback form → click Request Callback → modal → signup → callback sends automatically
- [ ] "Already have an account? Sign in" toggle still works for returning users
- [ ] Non-modal /auth page is visually unchanged (compact-mode-only spacing changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)