### PR TITLE
Modal attachments + buttonless popups, and admin analytics exclusion

### DIFF
--- a/src/components/admin/ModalEditor.tsx
+++ b/src/components/admin/ModalEditor.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
-import { Save, X, Plus, Trash2, ChevronLeft } from 'lucide-react';
-import { CreateModalInput, ModalPopup } from '../../services/modals';
+import React, { useState } from 'react';
+import { Save, X, Plus, Trash2, ChevronLeft, Upload, Paperclip, Loader2 } from 'lucide-react';
+import { CreateModalInput, ModalPopup, modalsService, getModalAttachmentUrl } from '../../services/modals';
 import { ModalPreview } from './ModalPreview';
 
 interface ModalEditorProps {
   modalForm: CreateModalInput;
   isEditing: boolean;
+  editingModalId: string | null;
   onSave: () => void;
   onCancel: () => void;
   onChange: (updates: Partial<CreateModalInput>) => void;
@@ -29,7 +30,49 @@ const FREQUENCY_OPTIONS = [
   { value: 'custom_interval', label: 'Custom interval' },
 ];
 
-export function ModalEditor({ modalForm, isEditing, onSave, onCancel, onChange }: ModalEditorProps) {
+export function ModalEditor({ modalForm, isEditing, editingModalId, onSave, onCancel, onChange }: ModalEditorProps) {
+  const [uploadingAttachment, setUploadingAttachment] = useState(false);
+  const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const fileInputRef = React.useRef<HTMLInputElement | null>(null);
+
+  const hasAttachment = !!modalForm.attachment_path;
+
+  const handleAttachmentSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file || !editingModalId) return;
+
+    setUploadingAttachment(true);
+    setAttachmentError(null);
+    try {
+      if (modalForm.attachment_path) {
+        await modalsService.deleteModalAttachment(modalForm.attachment_path);
+      }
+      const { path, filename } = await modalsService.uploadModalAttachment(editingModalId, file);
+      onChange({ attachment_path: path, attachment_filename: filename });
+    } catch (err: any) {
+      console.error('Modal attachment upload failed:', err);
+      setAttachmentError(err?.message || 'Upload failed');
+    } finally {
+      setUploadingAttachment(false);
+    }
+  };
+
+  const handleRemoveAttachment = async () => {
+    if (!modalForm.attachment_path) return;
+    setUploadingAttachment(true);
+    setAttachmentError(null);
+    try {
+      await modalsService.deleteModalAttachment(modalForm.attachment_path);
+      onChange({ attachment_path: null, attachment_filename: null });
+    } catch (err: any) {
+      console.error('Modal attachment delete failed:', err);
+      setAttachmentError(err?.message || 'Delete failed');
+    } finally {
+      setUploadingAttachment(false);
+    }
+  };
+
   const handleAddTextLine = () => {
     onChange({
       additional_text_lines: [...(modalForm.additional_text_lines || []), '']
@@ -63,8 +106,10 @@ export function ModalEditor({ modalForm, isEditing, onSave, onCancel, onChange }
     heading: modalForm.heading,
     subheading: modalForm.subheading,
     additional_text_lines: modalForm.additional_text_lines || [],
-    button_text: modalForm.button_text,
-    button_url: modalForm.button_url,
+    button_text: modalForm.button_text || null,
+    button_url: modalForm.button_url || null,
+    attachment_path: modalForm.attachment_path || null,
+    attachment_filename: modalForm.attachment_filename || null,
     is_active: modalForm.is_active || false,
     trigger_pages: modalForm.trigger_pages || [],
     display_frequency: modalForm.display_frequency || 'once_per_session',
@@ -194,38 +239,132 @@ export function ModalEditor({ modalForm, isEditing, onSave, onCancel, onChange }
                 </div>
               </div>
 
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Button Text <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="text"
-                  value={modalForm.button_text}
-                  onChange={(e) => onChange({ button_text: e.target.value })}
-                  placeholder="Join Now!"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-accent-500 focus:border-transparent"
-                />
+              <div className="border-t border-gray-100 pt-4 space-y-4">
+                <div>
+                  <h4 className="text-sm font-semibold text-gray-900">Action button</h4>
+                  <p className="text-xs text-gray-500 mt-1">
+                    Optional. Leave both fields blank and skip the attachment to post a modal with no button.
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Button Text
+                  </label>
+                  <input
+                    type="text"
+                    value={modalForm.button_text || ''}
+                    onChange={(e) => onChange({ button_text: e.target.value })}
+                    placeholder={hasAttachment ? 'Download now' : 'Join Now!'}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-accent-500 focus:border-transparent"
+                  />
+                  {hasAttachment && (
+                    <p className="mt-1 text-xs text-gray-500">
+                      Defaults to "Download now" if left blank. The button will download the attached file.
+                    </p>
+                  )}
+                </div>
+
+                {!hasAttachment && (
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Button URL
+                    </label>
+                    <input
+                      type="text"
+                      value={modalForm.button_url || ''}
+                      onChange={(e) => onChange({ button_url: e.target.value })}
+                      onBlur={(e) => {
+                        let url = e.target.value.trim();
+                        if (url && !url.match(/^[a-zA-Z]+:\/\//)) {
+                          onChange({ button_url: 'https://' + url });
+                        }
+                      }}
+                      placeholder="https://chat.whatsapp.com/... or amazon.com"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-accent-500 focus:border-transparent"
+                    />
+                    <p className="mt-1 text-xs text-gray-500">
+                      Opens in a new tab. https:// will be added automatically if missing. Leave blank if using an attachment instead.
+                    </p>
+                  </div>
+                )}
               </div>
 
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Button URL <span className="text-red-500">*</span>
-                </label>
+              <div className="border-t border-gray-100 pt-4 space-y-3">
+                <div>
+                  <h4 className="text-sm font-semibold text-gray-900 flex items-center gap-2">
+                    <Paperclip className="w-4 h-4" />
+                    Download attachment
+                  </h4>
+                  <p className="text-xs text-gray-500 mt-1">
+                    Optional. Upload any file (document, image, etc.) and the modal button will download it.
+                  </p>
+                </div>
+
+                {!isEditing && (
+                  <div className="text-sm text-gray-600 bg-gray-50 border border-gray-200 rounded-md p-3">
+                    Save this modal first, then re-open it to upload an attachment.
+                  </div>
+                )}
+
+                {isEditing && hasAttachment && (
+                  <div className="flex items-center gap-3 bg-gray-50 border border-gray-200 rounded-md p-3">
+                    <Paperclip className="w-4 h-4 text-gray-500 flex-shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <a
+                        href={getModalAttachmentUrl(modalForm.attachment_path) || '#'}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm text-blue-600 hover:underline truncate block"
+                      >
+                        {modalForm.attachment_filename || 'attachment'}
+                      </a>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => fileInputRef.current?.click()}
+                      disabled={uploadingAttachment}
+                      className="text-xs text-gray-600 hover:text-gray-900 px-2 py-1 rounded hover:bg-gray-100 disabled:opacity-50"
+                    >
+                      Replace
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleRemoveAttachment}
+                      disabled={uploadingAttachment}
+                      className="text-xs text-red-600 hover:text-red-700 px-2 py-1 rounded hover:bg-red-50 disabled:opacity-50"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                )}
+
+                {isEditing && !hasAttachment && (
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={uploadingAttachment}
+                    className="flex items-center gap-2 px-3 py-2 text-sm border border-dashed border-gray-300 rounded-md text-gray-600 hover:bg-gray-50 disabled:opacity-50"
+                  >
+                    {uploadingAttachment ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <Upload className="w-4 h-4" />
+                    )}
+                    {uploadingAttachment ? 'Uploading…' : 'Upload file'}
+                  </button>
+                )}
+
+                {attachmentError && (
+                  <p className="text-xs text-red-600">{attachmentError}</p>
+                )}
+
                 <input
-                  type="text"
-                  value={modalForm.button_url}
-                  onChange={(e) => onChange({ button_url: e.target.value })}
-                  onBlur={(e) => {
-                    let url = e.target.value.trim();
-                    // Auto-add https:// if no protocol is specified and URL is not empty
-                    if (url && !url.match(/^[a-zA-Z]+:\/\//)) {
-                      onChange({ button_url: 'https://' + url });
-                    }
-                  }}
-                  placeholder="https://chat.whatsapp.com/... or amazon.com"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-accent-500 focus:border-transparent"
+                  ref={fileInputRef}
+                  type="file"
+                  className="hidden"
+                  onChange={handleAttachmentSelect}
                 />
-                <p className="mt-1 text-xs text-gray-500">Opens in a new tab. https:// will be added automatically if missing.</p>
               </div>
 
               <div className="flex items-center gap-2">

--- a/src/components/admin/ModalManagement.tsx
+++ b/src/components/admin/ModalManagement.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Search, Plus, Eye, EyeOff, Edit2, Trash2, Power, Save, X, BarChart3 } from 'lucide-react';
+import { Search, Plus, Eye, EyeOff, Edit2, Trash2, Power, Save, X, BarChart3, Paperclip } from 'lucide-react';
 import { ModalPopup, CreateModalInput } from '../../services/modals';
 import { ModalPreview } from './ModalPreview';
 
@@ -111,7 +111,14 @@ export function ModalManagement({ modals, modalStats, onToggleActive, onDelete, 
                   <tr key={modal.id} className="hover:bg-gray-50">
                     <td className="px-6 py-4">
                       <div>
-                        <div className="font-medium text-gray-900">{modal.name}</div>
+                        <div className="font-medium text-gray-900 flex items-center gap-2">
+                          {modal.name}
+                          {modal.attachment_path && (
+                            <span title={modal.attachment_filename || 'Attachment'} className="text-gray-400">
+                              <Paperclip className="w-3.5 h-3.5" />
+                            </span>
+                          )}
+                        </div>
                         <div className="text-sm text-gray-500">{modal.heading}</div>
                       </div>
                     </td>

--- a/src/components/admin/ModalPreview.tsx
+++ b/src/components/admin/ModalPreview.tsx
@@ -74,16 +74,18 @@ export function ModalPreview({ modal }: ModalPreviewProps) {
               </div>
             )}
 
-            <div className="pt-4">
-              <button
-                disabled
-                className={`w-full bg-accent-500 text-white rounded-md font-medium transition-colors cursor-not-allowed ${
-                  viewMode === 'mobile' ? 'px-4 py-2 text-sm' : 'px-6 py-3 text-base'
-                }`}
-              >
-                {modal.button_text || 'Click Here'}
-              </button>
-            </div>
+            {(modal.attachment_path || modal.button_text) && (
+              <div className="pt-4">
+                <button
+                  disabled
+                  className={`w-full bg-accent-500 text-white rounded-md font-medium transition-colors cursor-not-allowed ${
+                    viewMode === 'mobile' ? 'px-4 py-2 text-sm' : 'px-6 py-3 text-base'
+                  }`}
+                >
+                  {modal.button_text || (modal.attachment_path ? 'Download now' : 'Click Here')}
+                </button>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/shared/CustomModal.tsx
+++ b/src/components/shared/CustomModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { X } from 'lucide-react';
-import type { ModalPopup } from '../../services/modals';
+import { getModalAttachmentUrl, type ModalPopup } from '../../services/modals';
 
 interface CustomModalProps {
   modal: ModalPopup;
@@ -12,14 +12,34 @@ interface CustomModalProps {
 export function CustomModal({ modal, isOpen, onClose, onButtonClick }: CustomModalProps) {
   if (!isOpen) return null;
 
+  const attachmentUrl = getModalAttachmentUrl(modal.attachment_path);
+  const hasAttachment = !!attachmentUrl;
+  const hasUrlButton = !hasAttachment && !!modal.button_url;
+  const showButton = hasAttachment || hasUrlButton;
+  const buttonLabel = modal.button_text || (hasAttachment ? 'Download now' : '');
+
   const handleButtonClick = () => {
     onButtonClick();
-    // Ensure URL has protocol - if missing, add https://
-    let url = modal.button_url;
+
+    if (hasAttachment && attachmentUrl) {
+      const link = document.createElement('a');
+      link.href = attachmentUrl;
+      link.download = modal.attachment_filename || '';
+      link.rel = 'noopener noreferrer';
+      link.target = '_blank';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      return;
+    }
+
+    let url = modal.button_url || '';
     if (url && !url.match(/^[a-zA-Z]+:\/\//)) {
       url = 'https://' + url;
     }
-    window.open(url, '_blank', 'noopener,noreferrer');
+    if (url) {
+      window.open(url, '_blank', 'noopener,noreferrer');
+    }
   };
 
   const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -78,14 +98,16 @@ export function CustomModal({ modal, isOpen, onClose, onButtonClick }: CustomMod
             </div>
           )}
 
-          <div className="pt-4">
-            <button
-              onClick={handleButtonClick}
-              className="w-full bg-accent-500 text-white px-6 py-3 rounded-md font-medium hover:bg-accent-600 transition-colors focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-offset-2"
-            >
-              {modal.button_text}
-            </button>
-          </div>
+          {showButton && (
+            <div className="pt-4">
+              <button
+                onClick={handleButtonClick}
+                className="w-full bg-accent-500 text-white px-6 py-3 rounded-md font-medium hover:bg-accent-600 transition-colors focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-offset-2"
+              >
+                {buttonLabel}
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/hooks/useAnalyticsInit.ts
+++ b/src/hooks/useAnalyticsInit.ts
@@ -2,13 +2,13 @@ import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
 import { supabase } from '@/config/supabase';
-import { initAnalytics, setUserId, track } from '@/lib/analytics';
+import { initAnalytics, setSuppressAnalytics, setUserId, track } from '@/lib/analytics';
 import { useAuth } from './useAuth';
 
 export function useAnalyticsInit(): void {
   const location = useLocation();
   const previousPathname = useRef<string | null>(null);
-  const { user, profile } = useAuth();
+  const { user, profile, loading } = useAuth();
 
   useEffect(() => {
     initAnalytics(supabase);
@@ -29,6 +29,17 @@ export function useAnalyticsInit(): void {
       Sentry.setUser(null);
     }
   }, [user?.id, profile?.role]);
+
+  useEffect(() => {
+    // Resolve admin gating once auth is done loading. While loading, leave
+    // suppression as `null` so events queue but do not flush — this prevents
+    // leaking an admin's initial page_view / session_start before we know
+    // who they are. Re-evaluates if profile.is_admin changes (login/logout).
+    if (loading) {
+      return;
+    }
+    setSuppressAnalytics(profile?.is_admin === true);
+  }, [loading, profile?.is_admin]);
 
   useEffect(() => {
     const pathname = location.pathname;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -39,6 +39,11 @@ let cachedAnonId: string | null = null;
 let currentSessionId: string | null = null;
 let lastActivityMs = 0;
 let currentUserId: string | null = null;
+// Admin-aware suppression. null = unknown (queue but do not flush yet),
+// true = suppress (drop everything, admin user), false = allow (flush normally).
+// Holding events while unknown prevents leaking the initial page_view /
+// session_start of an admin before their profile has loaded.
+let suppressEvents: boolean | null = null;
 const eventQueue: PendingEvent[] = [];
 const sessionFlags = new Set<string>();
 
@@ -177,6 +182,10 @@ function enqueueEvent(
   props: Record<string, unknown> = {},
   occurredAt?: string,
 ): void {
+  if (suppressEvents === true) {
+    return;
+  }
+
   const payload: PendingEvent = {
     session_id: sessionId,
     anon_id: getAnonId(),
@@ -205,6 +214,12 @@ function enqueueEvent(
 }
 
 async function flushEvents(options: { useKeepalive?: boolean } = {}): Promise<void> {
+  // Wait until we know whether this user is an admin. If admin, we'll drop
+  // the queue; if not, we'll flush. Either way, do not send before resolution.
+  if (suppressEvents !== false) {
+    return;
+  }
+
   if (!eventQueue.length) {
     return;
   }
@@ -385,6 +400,30 @@ export function setUserId(userId?: string | null): void {
   currentUserId = userId ?? null;
 }
 
+/**
+ * Gate analytics on admin status. Pass `true` to suppress all tracking for
+ * the current user (admin), `false` to allow it (non-admin), or `null` to
+ * mark status as unknown — events still queue but won't be sent until
+ * resolved. Call once auth + profile have loaded, and again on changes
+ * (e.g., admin signs out).
+ */
+export function setSuppressAnalytics(suppress: boolean | null): void {
+  const previous = suppressEvents;
+  suppressEvents = suppress;
+
+  if (suppress === true) {
+    eventQueue.splice(0, eventQueue.length);
+    if (ANALYTICS_DEBUG) {
+      console.log('[analytics] admin detected — suppressing all events');
+    }
+    return;
+  }
+
+  if (suppress === false && previous !== false) {
+    void flushEvents();
+  }
+}
+
 export function track(eventName: AnalyticsEventName, props: Record<string, unknown> = {}): void {
   const sessionId = ensureSession(Date.now());
   enqueueEvent(sessionId, eventName, props);
@@ -524,6 +563,59 @@ export function trackLoginGateActionCompleted(
     listing_id: props.listingId,
     listing_type: props.listingType,
     method: props.method,
+  });
+}
+
+// ── Post-listing wizard funnel ────────────────────────────────────
+// Per-step events linked back to the per-attempt `attempt_id` already
+// minted by getPostingSession(), so the wizard funnel can be joined to
+// post_started/post_submitted/post_success in BI.
+//
+// Drop-off detection is implicit: the last `wizard_step_viewed` for an
+// attempt is where the user stopped.
+//
+// We don't emit on backward navigation (per product spec — we only
+// care about how far forward they got).
+
+export type WizardFunnelPath =
+  | 'residential_rental'
+  | 'residential_sale'
+  | 'commercial_rental'
+  | 'commercial_sale';
+
+interface WizardStepBaseProps {
+  path: WizardFunnelPath;
+  step: number;        // zero-indexed position in the step sequence
+  totalSteps: number;  // length of that path's step sequence
+}
+
+export function trackWizardStepViewed(props: WizardStepBaseProps): void {
+  const { attemptId } = getPostingSession();
+  const flagKey = `${SESSION_FLAG_PREFIX}wiz:viewed:${attemptId}:${props.path}:${props.step}`;
+  if (getFlag(flagKey)) {
+    return; // Already counted this step view for this attempt; ignore.
+  }
+  setFlag(flagKey);
+  track('wizard_step_viewed', {
+    attempt_id: attemptId,
+    path: props.path,
+    step: props.step,
+    total_steps: props.totalSteps,
+  });
+}
+
+export function trackWizardStepCompleted(props: WizardStepBaseProps): void {
+  const { attemptId } = getPostingSession();
+  const flagKey = `${SESSION_FLAG_PREFIX}wiz:done:${attemptId}:${props.path}:${props.step}`;
+  if (getFlag(flagKey)) {
+    return;
+  }
+  setFlag(flagKey);
+  track('wizard_step_completed', {
+    attempt_id: attemptId,
+    path: props.path,
+    step: props.step,
+    total_steps: props.totalSteps,
   });
 }
 

--- a/src/pages/ContentManagement.tsx
+++ b/src/pages/ContentManagement.tsx
@@ -54,6 +54,8 @@ export function ContentManagement() {
     additional_text_lines: [],
     button_text: '',
     button_url: '',
+    attachment_path: null,
+    attachment_filename: null,
     is_active: false,
     trigger_pages: [],
     display_frequency: 'once_per_session',
@@ -269,17 +271,20 @@ export function ContentManagement() {
       setSelectedModal(newModal);
       setEditingModalId(newModal.id);
       setModalForm({
-        name: '',
-        heading: '',
-        subheading: '',
-        additional_text_lines: [],
-        button_text: '',
-        button_url: '',
-        is_active: false,
-        trigger_pages: [],
-        display_frequency: 'once_per_session',
-        delay_seconds: 0,
-        priority: 0,
+        name: newModal.name,
+        heading: newModal.heading,
+        subheading: newModal.subheading || '',
+        additional_text_lines: newModal.additional_text_lines || [],
+        button_text: newModal.button_text || '',
+        button_url: newModal.button_url || '',
+        attachment_path: newModal.attachment_path,
+        attachment_filename: newModal.attachment_filename,
+        is_active: newModal.is_active,
+        trigger_pages: newModal.trigger_pages || [],
+        display_frequency: newModal.display_frequency,
+        custom_interval_hours: newModal.custom_interval_hours,
+        delay_seconds: newModal.delay_seconds,
+        priority: newModal.priority,
       });
       loadData();
     } catch (error) {
@@ -296,8 +301,10 @@ export function ContentManagement() {
       heading: modal.heading,
       subheading: modal.subheading || '',
       additional_text_lines: modal.additional_text_lines || [],
-      button_text: modal.button_text,
-      button_url: modal.button_url,
+      button_text: modal.button_text || '',
+      button_url: modal.button_url || '',
+      attachment_path: modal.attachment_path,
+      attachment_filename: modal.attachment_filename,
       is_active: modal.is_active,
       trigger_pages: modal.trigger_pages || [],
       display_frequency: modal.display_frequency,
@@ -332,6 +339,8 @@ export function ContentManagement() {
       additional_text_lines: [],
       button_text: '',
       button_url: '',
+      attachment_path: null,
+      attachment_filename: null,
       is_active: false,
       trigger_pages: [],
       display_frequency: 'once_per_session',
@@ -823,6 +832,7 @@ export function ContentManagement() {
                       <ModalEditor
                         modalForm={modalForm}
                         isEditing={!!editingModalId}
+                        editingModalId={editingModalId}
                         onSave={editingModalId ? handleSaveModal : handleCreateModal}
                         onCancel={handleCancelModalEdit}
                         onChange={(updates) => setModalForm(prev => ({ ...prev, ...updates }))}
@@ -842,6 +852,8 @@ export function ContentManagement() {
                             additional_text_lines: [],
                             button_text: '',
                             button_url: '',
+                            attachment_path: null,
+                            attachment_filename: null,
                             is_active: false,
                             trigger_pages: [],
                             display_frequency: 'once_per_session',

--- a/src/services/modals.ts
+++ b/src/services/modals.ts
@@ -6,8 +6,10 @@ export interface ModalPopup {
   heading: string;
   subheading?: string;
   additional_text_lines: string[];
-  button_text: string;
-  button_url: string;
+  button_text: string | null;
+  button_url: string | null;
+  attachment_path: string | null;
+  attachment_filename: string | null;
   is_active: boolean;
   trigger_pages: string[];
   display_frequency: 'once_per_session' | 'once_per_day' | 'once_per_lifetime' | 'until_clicked' | 'custom_interval';
@@ -16,6 +18,14 @@ export interface ModalPopup {
   priority: number;
   created_at: string;
   updated_at: string;
+}
+
+const MODAL_ATTACHMENTS_BUCKET = 'modal-attachments';
+
+export function getModalAttachmentUrl(path: string | null | undefined): string | null {
+  if (!path) return null;
+  const { data } = supabase.storage.from(MODAL_ATTACHMENTS_BUCKET).getPublicUrl(path);
+  return data.publicUrl;
 }
 
 export interface ModalUserInteraction {
@@ -34,8 +44,10 @@ export interface CreateModalInput {
   heading: string;
   subheading?: string;
   additional_text_lines?: string[];
-  button_text: string;
-  button_url: string;
+  button_text?: string | null;
+  button_url?: string | null;
+  attachment_path?: string | null;
+  attachment_filename?: string | null;
   is_active?: boolean;
   trigger_pages?: string[];
   display_frequency?: ModalPopup['display_frequency'];
@@ -99,8 +111,10 @@ export const modalsService = {
         heading: input.heading,
         subheading: input.subheading || null,
         additional_text_lines: input.additional_text_lines || [],
-        button_text: input.button_text,
-        button_url: input.button_url,
+        button_text: input.button_text || null,
+        button_url: input.button_url || null,
+        attachment_path: input.attachment_path || null,
+        attachment_filename: input.attachment_filename || null,
         is_active: input.is_active ?? false,
         trigger_pages: input.trigger_pages || [],
         display_frequency: input.display_frequency || 'once_per_session',
@@ -126,8 +140,10 @@ export const modalsService = {
     if (input.heading !== undefined) updateData.heading = input.heading;
     if (input.subheading !== undefined) updateData.subheading = input.subheading || null;
     if (input.additional_text_lines !== undefined) updateData.additional_text_lines = input.additional_text_lines;
-    if (input.button_text !== undefined) updateData.button_text = input.button_text;
-    if (input.button_url !== undefined) updateData.button_url = input.button_url;
+    if (input.button_text !== undefined) updateData.button_text = input.button_text || null;
+    if (input.button_url !== undefined) updateData.button_url = input.button_url || null;
+    if (input.attachment_path !== undefined) updateData.attachment_path = input.attachment_path || null;
+    if (input.attachment_filename !== undefined) updateData.attachment_filename = input.attachment_filename || null;
     if (input.is_active !== undefined) updateData.is_active = input.is_active;
     if (input.trigger_pages !== undefined) updateData.trigger_pages = input.trigger_pages;
     if (input.display_frequency !== undefined) updateData.display_frequency = input.display_frequency;
@@ -151,6 +167,21 @@ export const modalsService = {
   },
 
   async deleteModal(id: string): Promise<void> {
+    const { data: existing } = await supabase
+      .from('modal_popups')
+      .select('attachment_path')
+      .eq('id', id)
+      .maybeSingle();
+
+    if (existing?.attachment_path) {
+      const { error: storageError } = await supabase.storage
+        .from(MODAL_ATTACHMENTS_BUCKET)
+        .remove([existing.attachment_path]);
+      if (storageError) {
+        console.error('Error removing modal attachment file:', storageError);
+      }
+    }
+
     const { error } = await supabase
       .from('modal_popups')
       .delete()
@@ -158,6 +189,37 @@ export const modalsService = {
 
     if (error) {
       console.error('Error deleting modal:', error);
+      throw error;
+    }
+  },
+
+  async uploadModalAttachment(modalId: string, file: File): Promise<{ path: string; filename: string }> {
+    const ext = file.name.includes('.') ? file.name.split('.').pop() : 'bin';
+    const path = `${modalId}/${Date.now()}.${ext}`;
+
+    const { error } = await supabase.storage
+      .from(MODAL_ATTACHMENTS_BUCKET)
+      .upload(path, file, {
+        cacheControl: '3600',
+        upsert: false,
+        contentType: file.type || undefined,
+      });
+
+    if (error) {
+      console.error('Error uploading modal attachment:', error);
+      throw error;
+    }
+
+    return { path, filename: file.name };
+  },
+
+  async deleteModalAttachment(path: string): Promise<void> {
+    const { error } = await supabase.storage
+      .from(MODAL_ATTACHMENTS_BUCKET)
+      .remove([path]);
+
+    if (error) {
+      console.error('Error deleting modal attachment:', error);
       throw error;
     }
   },

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -39,6 +39,36 @@ export type Database = {
   }
   public: {
     Tables: {
+      admin_audit_log: {
+        Row: {
+          action: string
+          actor_id: string
+          created_at: string
+          details: Json | null
+          id: string
+          ip_hash: string | null
+          target_id: string | null
+        }
+        Insert: {
+          action: string
+          actor_id: string
+          created_at?: string
+          details?: Json | null
+          id?: string
+          ip_hash?: string | null
+          target_id?: string | null
+        }
+        Update: {
+          action?: string
+          actor_id?: string
+          created_at?: string
+          details?: Json | null
+          id?: string
+          ip_hash?: string | null
+          target_id?: string | null
+        }
+        Relationships: []
+      }
       admin_settings: {
         Row: {
           featured_duration_days: number | null
@@ -742,7 +772,22 @@ export type Database = {
           year_renovated?: number | null
           zoning_code?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "commercial_listings_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "commercial_listings_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "public_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       concierge_submissions: {
         Row: {
@@ -2420,8 +2465,10 @@ export type Database = {
       modal_popups: {
         Row: {
           additional_text_lines: Json | null
-          button_text: string
-          button_url: string
+          attachment_filename: string | null
+          attachment_path: string | null
+          button_text: string | null
+          button_url: string | null
           created_at: string | null
           custom_interval_hours: number | null
           delay_seconds: number | null
@@ -2437,8 +2484,10 @@ export type Database = {
         }
         Insert: {
           additional_text_lines?: Json | null
-          button_text: string
-          button_url: string
+          attachment_filename?: string | null
+          attachment_path?: string | null
+          button_text?: string | null
+          button_url?: string | null
           created_at?: string | null
           custom_interval_hours?: number | null
           delay_seconds?: number | null
@@ -2454,8 +2503,10 @@ export type Database = {
         }
         Update: {
           additional_text_lines?: Json | null
-          button_text?: string
-          button_url?: string
+          attachment_filename?: string | null
+          attachment_path?: string | null
+          button_text?: string | null
+          button_url?: string | null
           created_at?: string | null
           custom_interval_hours?: number | null
           delay_seconds?: number | null
@@ -3399,6 +3450,24 @@ export type Database = {
           views: number
         }[]
       }
+      analytics_login_gate_funnel: {
+        Args: { days_back?: number; tz?: string }
+        Returns: {
+          action_completed_reveal_phone: number
+          action_completed_send_callback: number
+          action_completed_total: number
+          auth_success_email_signin: number
+          auth_success_email_signup: number
+          auth_success_google: number
+          auth_success_total: number
+          dismissed_reveal_phone: number
+          dismissed_send_callback: number
+          dismissed_total: number
+          shown_reveal_phone: number
+          shown_send_callback: number
+          shown_total: number
+        }[]
+      }
       analytics_page_impressions: {
         Args: { days_back?: number; limit_count?: number; tz?: string }
         Returns: {
@@ -3528,6 +3597,15 @@ export type Database = {
           metric_name: string
           status: string
           variance_percent: number
+        }[]
+      }
+      analytics_wizard_funnel: {
+        Args: { days_back?: number; tz?: string }
+        Returns: {
+          completed: number
+          path: string
+          step: number
+          viewed: number
         }[]
       }
       analytics_zero_inquiry_listings: {
@@ -3680,6 +3758,10 @@ export type Database = {
           isSetofReturn: false
         }
       }
+      get_distinct_agency_names: {
+        Args: { search_text: string }
+        Returns: string[]
+      }
       get_featured_listings_count: { Args: never; Returns: number }
       get_featured_listings_count_by_user: {
         Args: { user_id: string }
@@ -3705,6 +3787,14 @@ export type Database = {
         }[]
       }
       get_sales_feature_enabled: { Args: never; Returns: boolean }
+      get_user_listing_counts: {
+        Args: never
+        Returns: {
+          featured_count: number
+          listing_count: number
+          user_id: string
+        }[]
+      }
       get_user_permissions: {
         Args: { p_user_id: string }
         Returns: {

--- a/supabase/functions/track/index.ts
+++ b/supabase/functions/track/index.ts
@@ -285,7 +285,53 @@ Deno.serve(async (req) => {
       }
     }
 
-    const { error } = await supabaseAdmin.from('analytics_events').insert(normalizedEvents);
+    // Defense-in-depth admin gate: drop any event whose user_id belongs to
+    // an admin profile. Catches events from stale clients or any that escape
+    // the client-side suppression in src/lib/analytics.ts.
+    const candidateUserIds = Array.from(
+      new Set(
+        normalizedEvents
+          .map((e) => e.user_id)
+          .filter((id): id is string => typeof id === 'string' && UUID_RE.test(id)),
+      ),
+    );
+
+    const adminUserIds = new Set<string>();
+    if (candidateUserIds.length > 0) {
+      const { data: adminRows, error: adminLookupError } = await supabaseAdmin
+        .from('profiles')
+        .select('id')
+        .in('id', candidateUserIds)
+        .eq('is_admin', true);
+
+      if (adminLookupError) {
+        console.error('Admin lookup failed; proceeding without admin filter', adminLookupError);
+      } else {
+        for (const row of adminRows ?? []) {
+          if (row?.id) adminUserIds.add(row.id);
+        }
+      }
+    }
+
+    const filteredEvents = adminUserIds.size
+      ? normalizedEvents.filter((e) => !e.user_id || !adminUserIds.has(e.user_id))
+      : normalizedEvents;
+
+    if (adminUserIds.size) {
+      for (const sessionId of Array.from(sessionTouches.keys())) {
+        const touch = sessionTouches.get(sessionId);
+        if (touch?.user && adminUserIds.has(touch.user)) {
+          sessionTouches.delete(sessionId);
+          sessionEnds.delete(sessionId);
+        }
+      }
+    }
+
+    if (!filteredEvents.length) {
+      return jsonResponse(200, { success: true, inserted: 0 });
+    }
+
+    const { error } = await supabaseAdmin.from('analytics_events').insert(filteredEvents);
 
     if (error) {
       console.error('Failed to insert analytics events', error);
@@ -320,7 +366,7 @@ Deno.serve(async (req) => {
       }),
     );
 
-    return jsonResponse(200, { success: true, inserted: normalizedEvents.length });
+    return jsonResponse(200, { success: true, inserted: filteredEvents.length });
   } catch (error) {
     console.error('Track handler failure', error);
     return jsonResponse(500, { error: 'Unhandled analytics error' });

--- a/supabase/migrations/20260527120000_modal_attachments_and_optional_button.sql
+++ b/supabase/migrations/20260527120000_modal_attachments_and_optional_button.sql
@@ -1,0 +1,27 @@
+/*
+  # Make modal button fields optional and add attachment columns
+
+  ## Summary
+  Two related changes to `modal_popups`:
+  1. Allow modals to be posted with no CTA button (drop NOT NULL on button_text/button_url).
+  2. Allow modals to carry a downloadable file attachment stored in the
+     `modal-attachments` storage bucket (created in the next migration).
+
+  ## Changes
+  - `button_text`: NOT NULL -> NULL
+  - `button_url`:  NOT NULL -> NULL
+  - Add `attachment_path` (text, nullable) — storage object key, e.g. `{modalId}/{timestamp}.{ext}`
+  - Add `attachment_filename` (text, nullable) — original filename for display + download
+
+  ## Notes
+  - Existing rows already have non-null button fields; relaxing the constraint is forward-compatible.
+  - Attachment columns are nullable so existing rows need no backfill.
+  - Storage object lifecycle is managed in application code (uploaded on save,
+    removed when admin clicks "Remove attachment" or deletes the modal).
+*/
+
+ALTER TABLE modal_popups
+  ALTER COLUMN button_text DROP NOT NULL,
+  ALTER COLUMN button_url DROP NOT NULL,
+  ADD COLUMN IF NOT EXISTS attachment_path text,
+  ADD COLUMN IF NOT EXISTS attachment_filename text;

--- a/supabase/migrations/20260527120001_create_modal_attachments_bucket.sql
+++ b/supabase/migrations/20260527120001_create_modal_attachments_bucket.sql
@@ -1,0 +1,62 @@
+/*
+  # Create modal-attachments Storage Bucket
+
+  ## Summary
+  Storage bucket for files attached to admin-controlled modal popups. When an
+  admin uploads a file in the modal editor, it lands here and the modal renders
+  a "Download now" button that links to the public URL.
+
+  ## Changes
+  1. Storage Bucket
+    - Create `modal-attachments` bucket (public read for download links).
+    - ON CONFLICT DO NOTHING to be safe on re-run.
+
+  2. Row Level Security Policies
+    - Public can SELECT (so download links work for anonymous visitors).
+    - Only admins can INSERT / UPDATE / DELETE.
+
+  ## Notes
+  - Object naming convention: `{modalId}/{timestamp}.{ext}`.
+  - Cleanup on modal-delete is handled in application code (services/modals.ts).
+*/
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('modal-attachments', 'modal-attachments', true)
+ON CONFLICT (id) DO NOTHING;
+
+CREATE POLICY "Public can view modal attachments"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'modal-attachments');
+
+CREATE POLICY "Admins can upload modal attachments"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'modal-attachments'
+    AND EXISTS (
+      SELECT 1 FROM profiles
+      WHERE id = auth.uid() AND is_admin = true
+    )
+  );
+
+CREATE POLICY "Admins can update modal attachments"
+  ON storage.objects FOR UPDATE
+  TO authenticated
+  USING (
+    bucket_id = 'modal-attachments'
+    AND EXISTS (
+      SELECT 1 FROM profiles
+      WHERE id = auth.uid() AND is_admin = true
+    )
+  );
+
+CREATE POLICY "Admins can delete modal attachments"
+  ON storage.objects FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'modal-attachments'
+    AND EXISTS (
+      SELECT 1 FROM profiles
+      WHERE id = auth.uid() AND is_admin = true
+    )
+  );


### PR DESCRIPTION
## Summary
- **Modal popups** — admins can now attach files to modal popups, and modals can be configured without a button (buttonless variant). Includes editor/preview UI updates, a new Supabase storage bucket for attachments, and schema columns for optional button + attachment metadata.
- **Admin analytics exclusion** — the in-house Supabase analytics system now ignores logged-in admins from end to end. Client holds events until auth resolves, then drops the queue and blocks future events for admins; the `track` edge function additionally drops any admin-tagged event as defense in depth.

## Test plan
- [ ] Create / edit a modal popup with an attachment; confirm upload, preview, and display on the live modal
- [ ] Create a buttonless modal; confirm it renders without a CTA and dismisses cleanly
- [ ] Existing modals (with button, no attachment) continue to work unchanged
- [ ] Run the new migrations against a fresh DB without errors
- [ ] Signed out: events still POST to `…/functions/v1/track` as before
- [ ] Signed in as a non-admin: events still POST as before
- [ ] Signed in as admin: **zero** requests to `/functions/v1/track` (verify in DevTools → Network), and no new rows in `analytics_events` for that session
- [ ] Admin signs out mid-session: tracking resumes for anonymous browsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)