### PR TITLE
Remove login gate from phone reveal and callback request

### DIFF
--- a/src/pages/CommercialListingDetail.tsx
+++ b/src/pages/CommercialListingDetail.tsx
@@ -739,34 +739,13 @@ export function CommercialListingDetail() {
 
   const handleCallClick = (): boolean | void => {
     if (!listing?.id) return;
-    if (!user) {
-      savePendingListingAction({
-        type: 'reveal_phone',
-        listingId: listing.id,
-        listingType: 'commercial',
-      });
-      savePendingAuth({ from: window.location.pathname });
-      openAuthGate('reveal_phone');
-      return false;
-    }
     gaListing('commercial_listing_contact_click', listing.id, {
       contact_method: 'phone',
     });
   };
 
-  const handleCallbackAuthRequired = (formData: CommercialContactFormData) => {
-    if (!listing?.id) return;
-    savePendingListingAction({
-      type: 'send_callback',
-      listingId: listing.id,
-      listingType: 'commercial',
-      userName: formData.userName,
-      userPhone: formData.userPhone,
-      consentToFollowup: formData.consentToFollowup,
-    });
-    savePendingAuth({ from: window.location.pathname });
-    openAuthGate('send_callback');
-  };
+  // Phone/callback no longer requires login. Handler kept for type compatibility.
+  const handleCallbackAuthRequired = (_formData: CommercialContactFormData) => {};
 
   const handleAuthModalClose = () => {
     if (!user && authModalAction && listing?.id) {
@@ -820,7 +799,7 @@ export function CommercialListingDetail() {
       <div className="mb-6">
         <CommercialContactForm
           commercialListingId={listing.id}
-          isAuthenticated={!!user}
+          isAuthenticated={true}
           onAuthRequired={handleCallbackAuthRequired}
           defaultSuccess={callbackJustSent}
         />

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -404,33 +404,12 @@ export function ListingDetail() {
 
   const handleCallClick = (): boolean | void => {
     if (!listing?.id) return;
-    if (!user) {
-      savePendingListingAction({
-        type: "reveal_phone",
-        listingId: listing.id,
-        listingType: "rental",
-      });
-      savePendingAuth({ from: window.location.pathname });
-      openAuthGate("reveal_phone");
-      return false;
-    }
     gaListing("listing_contact_click", listing.id, { contact_method: "phone" });
     trackPhoneReveal(listing.id);
   };
 
-  const handleCallbackAuthRequired = (formData: ListingContactFormData) => {
-    if (!listing?.id) return;
-    savePendingListingAction({
-      type: "send_callback",
-      listingId: listing.id,
-      listingType: "rental",
-      userName: formData.userName,
-      userPhone: formData.userPhone,
-      consentToFollowup: formData.consentToFollowup,
-    });
-    savePendingAuth({ from: window.location.pathname });
-    openAuthGate("send_callback");
-  };
+  // Phone/callback no longer requires login. Handler kept for type compatibility.
+  const handleCallbackAuthRequired = (_formData: ListingContactFormData) => {};
 
   const handleAuthModalClose = () => {
     if (!user && authModalAction && listing?.id) {
@@ -850,7 +829,7 @@ export function ListingDetail() {
               <div className="mb-6">
                 <ListingContactForm
                   listingId={listing.id}
-                  isAuthenticated={!!user}
+                  isAuthenticated={true}
                   onAuthRequired={handleCallbackAuthRequired}
                   defaultSuccess={callbackJustSent}
                 />
@@ -1068,7 +1047,7 @@ export function ListingDetail() {
               <div className="mb-6">
                 <ListingContactForm
                   listingId={listing.id}
-                  isAuthenticated={!!user}
+                  isAuthenticated={true}
                   onAuthRequired={handleCallbackAuthRequired}
                   defaultSuccess={callbackJustSent}
                 />


### PR DESCRIPTION
## Summary
- Unauthenticated users can now reveal phone numbers and send callback requests on all listing detail pages (rentals, sales, commercial)
- Removed the auth-gate check from `handleCallClick` and `handleCallbackAuthRequired` in both `ListingDetail.tsx` and `CommercialListingDetail.tsx`
- All existing auth infrastructure (modal, pending action replay, analytics tracking) is left intact — the gate simply no longer fires

## Test plan
- [ ] Sign out, open a rental listing → reveal phone number without being prompted to log in
- [ ] Sign out, open a rental listing → submit callback form without being prompted to log in
- [ ] Sign out, open a commercial listing → reveal phone number without being prompted to log in
- [ ] Sign out, open a commercial listing → submit callback form without being prompted to log in
- [ ] Sign out, open a sale listing → reveal phone number without being prompted to log in
- [ ] Signed-in users still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)