### PR TITLE
Agent-free posting: agents post free, landlords still pay

### DIFF
--- a/AGENT_FREE_POSTING.md
+++ b/AGENT_FREE_POSTING.md
@@ -1,0 +1,68 @@
+# Agent-free posting — deploy & test runbook
+
+Lets **agents** post residential rentals for free (legacy behavior, normal
+admin-controlled expiration) while **landlords keep paying**. All the existing
+paid Agent/VIP subscription code stays intact and dormant — flip one switch to
+start charging agents in the future.
+
+Branch: `claude/agents-post-free` (off `main`).
+
+## Who is treated as an "agent" (posts free)
+
+While `admin_settings.charge_agents` is **false** (default), a residential-rental
+poster posts free if **ANY** of:
+
+1. `profiles.role = 'agent'`, OR
+2. `profiles.free_posting_agent = true` (admin manual toggle), OR
+3. lifetime listing count (all types, any status) **≥ 3**
+   (`get_user_lifetime_listing_count`).
+
+Free agents post with `payment_kind = 'legacy_free'` and the normal
+`admin_settings.rental_active_days` expiration. No trial, no $25, no
+subscription.
+
+When `charge_agents` is **true**, nobody is treated as a free agent here —
+agents fall back into the existing subscription / trial / $25 flow.
+
+Landlords (non-agents) are **unchanged** in all cases.
+
+## Deploy steps (in order)
+
+1. **Apply the migration.** Paste the contents of
+   `supabase/migrations/20260622000000_agent_free_posting.sql` into the Supabase
+   SQL editor (live project) and run it. It is additive and idempotent:
+   - adds `admin_settings.charge_agents` (default false)
+   - adds `profiles.free_posting_agent` (default false)
+   - creates `get_user_lifetime_listing_count(uuid)`
+
+2. **Regenerate DB types** (optional but recommended):
+   `npm run db:types`. The code uses targeted casts so it builds without this,
+   but regenerating keeps `src/types/database.ts` honest.
+
+3. **Deploy the frontend** (merge the PR to `main` once tested).
+
+No edge-function changes. No new env vars.
+
+## Admin controls
+
+- **Charge agents switch:** Admin → Subscriptions page, panel under the
+  monetization master switch. OFF = agents free (default). ON = agents pay.
+- **Per-user free-posting toggle:** Admin → Users table, "Free Posting" column.
+  Marks an individual user as a free-posting agent regardless of role/volume.
+
+## Test checklist (after migration applied)
+
+Monetization master switch must be **ON** for these (otherwise everyone is
+`disabled`/legacy and the agent branch is moot).
+
+- [ ] Landlord, `role=landlord`, < 3 lifetime listings, not flagged,
+      `charge_agents` OFF → still sees trial / $25 / must_pay. **(unchanged)**
+- [ ] `role=agent` → wizard shows "Free to post"; listing posts immediately,
+      `payment_kind=legacy_free`, `expires_at` ≈ now + `rental_active_days`.
+- [ ] Landlord with **3+ lifetime listings** → posts free (volume rule).
+- [ ] Admin flips a user's "Free Posting" toggle ON → that user posts free.
+- [ ] Flip **Charge agents ON** → an agent now sees the normal
+      subscription/trial/$25 flow again (dormant paid code still works).
+- [ ] Dashboard shows the agent's listing as a normal/legacy listing (no
+      "unknown" pill, no payment prompts).
+- [ ] Master monetization switch OFF → everyone posts legacy (unaffected).

--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -50,6 +50,7 @@ export interface Profile {
   can_feature_listings?: boolean;
   can_manage_agency?: boolean;
   can_post_sales?: boolean;
+  free_posting_agent?: boolean;
   max_featured_listings_per_user?: number;
   created_at: string;
   updated_at: string;

--- a/src/hooks/useMonetizationGate.ts
+++ b/src/hooks/useMonetizationGate.ts
@@ -10,14 +10,17 @@
 // until a valid phone is entered.
 
 import { useEffect, useState } from 'react';
+import { supabase } from '../config/supabase';
 import { subscriptionsService } from '../services/subscriptions';
 import { paymentsService } from '../services/payments';
 import { monetizationStatusService } from '../services/monetizationStatus';
+import { agentFreePostingService } from '../services/agentFreePosting';
 import type { ListingSubscription } from '../types/monetization';
 
 export type MonetizationGateMode =
   | 'loading'
   | 'disabled'       // monetization master switch is off — wizard posts the legacy way
+  | 'agent_free'     // user qualifies as an agent and charge_agents is off — posts free (legacy expiration)
   | 'subscription'
   | 'subscription_at_cap'
   | 'trial_eligible'
@@ -97,6 +100,34 @@ export function useMonetizationGate(opts: {
         return;
       }
 
+      // Agent-free posting: while admin_settings.charge_agents is off, users who
+      // qualify as agents (role=agent, admin-flagged, or high lifetime volume)
+      // post free with normal expiration — exactly like the pre-monetization
+      // path. Skipped (falls through to the paywall) when charge_agents is on.
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (cancelled) return;
+        if (user) {
+          const isFreeAgent = await agentFreePostingService.isUserFreeAgent(user.id);
+          if (cancelled) return;
+          if (isFreeAgent) {
+            setState({
+              mode: 'agent_free',
+              subscription: null,
+              subscriptionListingsUsed: 0,
+              errorMessage: null,
+            });
+            return;
+          }
+        }
+      } catch (err) {
+        // If the agent-free check can't run (e.g. columns/RPC missing because
+        // this migration hasn't been applied), fall through to the existing
+        // paywall rather than blocking the wizard.
+        console.warn('Agent-free eligibility check failed; using paywall:', err);
+        if (cancelled) return;
+      }
+
       try {
         const coverage = await subscriptionsService.canPostUnderSubscription();
         if (cancelled) return;
@@ -138,6 +169,7 @@ export function useMonetizationGate(opts: {
   useEffect(() => {
     if (!opts.enabled || opts.isAdmin) return;
     if (state.mode === 'disabled') return; // master switch off
+    if (state.mode === 'agent_free') return; // agent posts free; phone is irrelevant
     if (state.subscription) return; // already covered
 
     const normalized = phoneToE164(opts.contactPhone);

--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -133,6 +133,7 @@ export function AdminPanel() {
   const [toast, setToast] = useState<{ message: string; tone: 'success' | 'error' } | null>(null);
   const [updatingAgencyAccessId, setUpdatingAgencyAccessId] = useState<string | null>(null);
   const [updatingSalesAccessId, setUpdatingSalesAccessId] = useState<string | null>(null);
+  const [updatingFreeAgentId, setUpdatingFreeAgentId] = useState<string | null>(null);
   const [salesFeatureEnabled, setSalesFeatureEnabled] = useState(false);
   const [impersonatingUserId, setImpersonatingUserId] = useState<string | null>(null);
   const [rentalActiveDays, setRentalActiveDays] = useState<number>(30);
@@ -368,7 +369,7 @@ export function AdminPanel() {
       // when truncation is hiding rows from the admin.
       const { data: allUsers, count: usersCount } = await supabase
         .from('profiles')
-        .select('id, full_name, email, role, phone, agency, is_admin, is_banned, created_at, can_manage_agency, can_post_sales', { count: 'exact' })
+        .select('id, full_name, email, role, phone, agency, is_admin, is_banned, created_at, can_manage_agency, can_post_sales, free_posting_agent', { count: 'exact' })
         .order('created_at', { ascending: false });
 
       const { data: allListings, count: listingsCount } = await supabase
@@ -622,6 +623,47 @@ export function AdminPanel() {
       setToast({ message: "Couldn't update Sales Access. Try again.", tone: 'error' });
     } finally {
       setUpdatingSalesAccessId(null);
+    }
+  };
+
+  const handleToggleFreeAgent = async (targetUser: Profile) => {
+    if (!profile?.is_admin || updatingFreeAgentId === targetUser.id) {
+      return;
+    }
+
+    const previousValue = Boolean(targetUser.free_posting_agent);
+    const nextValue = !previousValue;
+
+    setUpdatingFreeAgentId(targetUser.id);
+    setUsers(prev =>
+      prev.map(user =>
+        user.id === targetUser.id ? { ...user, free_posting_agent: nextValue } : user
+      )
+    );
+
+    try {
+      const { error } = await supabase
+        .from('profiles')
+        .update({ free_posting_agent: nextValue })
+        .eq('id', targetUser.id);
+
+      if (error) {
+        throw error;
+      }
+
+      setToast({ message: 'Free posting (agent) updated', tone: 'success' });
+    } catch (error) {
+      console.error('Error updating free posting agent:', error);
+      setUsers(prev =>
+        prev.map(user =>
+          user.id === targetUser.id
+            ? { ...user, free_posting_agent: previousValue }
+            : user
+        )
+      );
+      setToast({ message: "Couldn't update Free posting. Try again.", tone: 'error' });
+    } finally {
+      setUpdatingFreeAgentId(null);
     }
   };
 
@@ -1235,6 +1277,11 @@ export function AdminPanel() {
                             Sales Access
                           </th>
                         )}
+                        {profile?.is_admin && (
+                          <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider" title="Marks the user as a free-posting agent (overrides the paywall while 'Charge agents' is off).">
+                            Free Posting
+                          </th>
+                        )}
                         <th className="hidden lg:table-cell px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                           <button
                             onClick={() => handleUsersSort('status')}
@@ -1335,6 +1382,27 @@ export function AdminPanel() {
                                 <span
                                   className={`inline-block h-5 w-5 transform rounded-full bg-white transition ${
                                     user.can_post_sales ? 'translate-x-5' : 'translate-x-1'
+                                  }`}
+                                />
+                              </button>
+                            </td>
+                          )}
+                          {profile?.is_admin && (
+                            <td className="px-4 py-3 align-top">
+                              <button
+                                type="button"
+                                role="switch"
+                                aria-checked={Boolean(user.free_posting_agent)}
+                                aria-label="Toggle free posting (agent)"
+                                onClick={() => handleToggleFreeAgent(user)}
+                                disabled={updatingFreeAgentId === user.id}
+                                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                                  user.free_posting_agent ? 'bg-[#4E4B43]' : 'bg-gray-300'
+                                } ${updatingFreeAgentId === user.id ? 'cursor-wait opacity-60' : 'cursor-pointer'}`}
+                              >
+                                <span
+                                  className={`inline-block h-5 w-5 transform rounded-full bg-white transition ${
+                                    user.free_posting_agent ? 'translate-x-5' : 'translate-x-1'
                                   }`}
                                 />
                               </button>

--- a/src/pages/AdminSubscriptions.tsx
+++ b/src/pages/AdminSubscriptions.tsx
@@ -28,6 +28,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { subscriptionsService } from '../services/subscriptions';
 import { paymentsService } from '../services/payments';
 import { monetizationStatusService, type MonetizationStatus } from '../services/monetizationStatus';
+import { agentFreePostingService } from '../services/agentFreePosting';
 import { GrantDaysModal } from '../components/admin/GrantDaysModal';
 import {
   formatCents,
@@ -502,6 +503,10 @@ export function AdminSubscriptions() {
   const [monetization, setMonetization] = useState<MonetizationStatus>({ enabled: false, enabledAt: null });
   const [activating, setActivating] = useState(false);
   const [activationResult, setActivationResult] = useState<string | null>(null);
+  // "Charge agents" switch. When OFF (default), agents post free; when ON they
+  // fall back into the existing paid subscription/trial/pay flow.
+  const [chargeAgents, setChargeAgents] = useState(false);
+  const [chargeAgentsSaving, setChargeAgentsSaving] = useState(false);
 
   // Admin guard
   useEffect(() => {
@@ -523,14 +528,16 @@ export function AdminSubscriptions() {
     setLoading(true);
     setErr(null);
     try {
-      const [subs, paid, status] = await Promise.all([
+      const [subs, paid, status, chargeAgentsOn] = await Promise.all([
         subscriptionsService.listAll(),
         paymentsService.adminListPaidListings(),
         monetizationStatusService.get(),
+        agentFreePostingService.getChargeAgents(),
       ]);
       setSubscribers(subs);
       setPaidListings(paid as PaidListingRow[]);
       setMonetization(status);
+      setChargeAgents(chargeAgentsOn);
     } catch (e) {
       setErr((e as Error).message);
     } finally {
@@ -581,6 +588,26 @@ export function AdminSubscriptions() {
       setErr((e as Error).message);
     } finally {
       setActivating(false);
+    }
+  };
+
+  const handleToggleChargeAgents = async () => {
+    const next = !chargeAgents;
+    const confirmed = window.confirm(
+      next
+        ? 'Turn ON "Charge agents"?\n\nAgents (role=agent, admin-flagged, or 3+ lifetime listings) will stop posting for free and fall back into the normal subscription / trial / $25 flow — the same as landlords. Continue?'
+        : 'Turn OFF "Charge agents"?\n\nAgents will go back to posting for free with the standard listing duration. Landlords still pay. Continue?',
+    );
+    if (!confirmed) return;
+    setChargeAgentsSaving(true);
+    setErr(null);
+    try {
+      await agentFreePostingService.setChargeAgents(next);
+      setChargeAgents(next);
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setChargeAgentsSaving(false);
     }
   };
 
@@ -722,6 +749,35 @@ export function AdminSubscriptions() {
               Activate monetization
             </button>
           )}
+        </div>
+
+        {/* Charge agents switch */}
+        <div className="mb-4 rounded-xl border border-gray-200 bg-white p-4 flex items-start gap-3">
+          <div className="flex-1 min-w-0">
+            <div className="font-semibold text-gray-900">
+              Charge agents {chargeAgents ? '(ON)' : '(OFF — agents post free)'}
+            </div>
+            <p className="text-sm mt-0.5 leading-relaxed text-gray-600">
+              {chargeAgents
+                ? 'Agents are billed like landlords: they go through the normal subscription / trial / $25 flow.'
+                : 'Agents (role = agent, admin-flagged, or 3+ lifetime listings) post residential rentals for free with the standard listing duration. Landlords still pay. Flip this on when you\'re ready to start charging agents — all the paid-plan code stays ready.'}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleToggleChargeAgents}
+            disabled={chargeAgentsSaving}
+            className={`flex-shrink-0 px-4 py-2 rounded-lg text-sm font-semibold disabled:opacity-50 inline-flex items-center gap-2 ${
+              chargeAgents
+                ? 'text-gray-600 hover:text-gray-900 border border-gray-300'
+                : 'bg-accent-600 hover:bg-accent-700 text-white'
+            }`}
+          >
+            {chargeAgentsSaving && (
+              <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+            )}
+            {chargeAgents ? 'Turn off (agents free)' : 'Turn on (charge agents)'}
+          </button>
         </div>
 
         {/* Tabs */}

--- a/src/pages/postListingWizard/PostListingWizard.tsx
+++ b/src/pages/postListingWizard/PostListingWizard.tsx
@@ -803,13 +803,17 @@ export function PostListingWizard() {
         // when it is posted. approve-listing stamps trial_started_at = now and
         // re-anchors paid_until from the payment ledger at approval time.
         // -----------------------------------------------------------------
+        //   agent_free           → 'legacy_free' (free-posting agent; normal
+        //                          admin-controlled expiration, no payment clock)
         ...(isSalePath || !paymentChoice
           ? {}
           : paymentChoice === 'subscription_covered'
             ? { payment_kind: 'subscription' }
             : paymentChoice === 'must_pay'
               ? { payment_kind: 'pending_payment' }
-              : { payment_kind: 'individual_trial' }),
+              : paymentChoice === 'agent_free'
+                ? { payment_kind: 'legacy_free' }
+                : { payment_kind: 'individual_trial' }),
       } as any;
 
       const listing = await listingsService.createListing(payload);

--- a/src/pages/postListingWizard/components/PaymentChoice.tsx
+++ b/src/pages/postListingWizard/components/PaymentChoice.tsx
@@ -65,6 +65,28 @@ export function PaymentChoice({
     return null;
   }
 
+  if (mode === 'agent_free') {
+    // The poster qualifies as an agent and charge_agents is off — they post
+    // free with the standard listing duration. Keep this calm and avoid
+    // surfacing any paid-plan options.
+    void choice;
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+        <div className="flex items-start gap-4">
+          <div className="w-10 h-10 rounded-lg bg-emerald-50 border border-emerald-100 flex items-center justify-center text-emerald-600 flex-shrink-0">
+            <ShieldCheck className="w-5 h-5" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h3 className="text-base font-semibold text-gray-900">Free to post</h3>
+            <p className="text-sm text-gray-500 mt-1">
+              Your listing posts at no charge and stays live for the standard listing period.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   if (mode === 'loading') {
     return (
       <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">

--- a/src/pages/postListingWizard/components/PaymentChoice.tsx
+++ b/src/pages/postListingWizard/components/PaymentChoice.tsx
@@ -15,7 +15,7 @@ import { Sparkles, ShieldCheck, Zap, Crown, ArrowUpRight, AlertTriangle } from '
 import type { MonetizationGateMode } from '../../../hooks/useMonetizationGate';
 import type { ListingSubscription } from '../../../types/monetization';
 
-export type WizardPaymentChoice = 'free_trial' | 'pay_at_posting' | 'must_pay' | 'subscription_covered' | 'admin';
+export type WizardPaymentChoice = 'free_trial' | 'pay_at_posting' | 'must_pay' | 'subscription_covered' | 'admin' | 'agent_free';
 
 // Persistence across sign-in (OAuth or modal). When a logged-out user fills
 // the wizard, hits submit, and signs in, the resulting OAuth redirect (or
@@ -30,7 +30,8 @@ export function isValidWizardPaymentChoice(v: unknown): v is WizardPaymentChoice
     v === 'pay_at_posting' ||
     v === 'must_pay' ||
     v === 'subscription_covered' ||
-    v === 'admin'
+    v === 'admin' ||
+    v === 'agent_free'
   );
 }
 

--- a/src/pages/postListingWizard/steps/residential/Step6ContactAndReview.tsx
+++ b/src/pages/postListingWizard/steps/residential/Step6ContactAndReview.tsx
@@ -132,8 +132,10 @@ export function Step6ContactAndReview({
   }, [paymentChoice]);
 
   useEffect(() => {
-    if (gate.mode === 'disabled') {
-      // Master switch off — clear any stored choice so the listing posts the legacy way.
+    if (gate.mode === 'disabled' || gate.mode === 'agent_free') {
+      // Master switch off, or the poster is a free-posting agent — clear any
+      // stored choice so the listing posts the legacy way (payment_kind NULL,
+      // normal admin-controlled expiration).
       setPaymentChoice(null);
     } else if (gate.mode === 'subscription') {
       setPaymentChoice('subscription_covered');
@@ -156,7 +158,10 @@ export function Step6ContactAndReview({
   const canSubmit =
     baseCanSubmit &&
     !isBlocked &&
-    (paymentChoice !== null || gate.mode === 'admin' || gate.mode === 'disabled');
+    (paymentChoice !== null ||
+      gate.mode === 'admin' ||
+      gate.mode === 'disabled' ||
+      gate.mode === 'agent_free');
 
   // When the submit button is disabled, explain why — a silent greyed-out
   // button with no feedback is impossible to debug for the poster.

--- a/src/pages/postListingWizard/steps/residential/Step6ContactAndReview.tsx
+++ b/src/pages/postListingWizard/steps/residential/Step6ContactAndReview.tsx
@@ -132,11 +132,15 @@ export function Step6ContactAndReview({
   }, [paymentChoice]);
 
   useEffect(() => {
-    if (gate.mode === 'disabled' || gate.mode === 'agent_free') {
-      // Master switch off, or the poster is a free-posting agent — clear any
-      // stored choice so the listing posts the legacy way (payment_kind NULL,
-      // normal admin-controlled expiration).
+    if (gate.mode === 'disabled') {
+      // Master switch off — clear any stored choice so the listing posts the
+      // legacy way (payment_kind NULL, normal admin-controlled expiration).
       setPaymentChoice(null);
+    } else if (gate.mode === 'agent_free') {
+      // Free-posting agent — post as legacy_free with the normal admin-controlled
+      // expiration. legacy_free (not NULL) so the dashboard/cron treat it
+      // correctly while monetization is on.
+      setPaymentChoice('agent_free');
     } else if (gate.mode === 'subscription') {
       setPaymentChoice('subscription_covered');
     } else if (gate.mode === 'admin') {

--- a/src/services/agentFreePosting.ts
+++ b/src/services/agentFreePosting.ts
@@ -1,0 +1,94 @@
+// Agent-free posting: decides whether a residential-rental poster qualifies as
+// an "agent" who posts for free (legacy behavior, normal admin-controlled
+// expiration) instead of going through the landlord paywall.
+//
+// Gated by admin_settings.charge_agents. While that is false (default), a user
+// is a free agent if ANY of:
+//   - profiles.role === 'agent', OR
+//   - profiles.free_posting_agent === true (admin manual override), OR
+//   - lifetime listing count (all types) >= AGENT_LIFETIME_LISTING_THRESHOLD.
+// When charge_agents is true, NOBODY is treated as a free agent here — agents
+// fall back into the existing subscription/trial/pay flow, which stays intact.
+//
+// Schema: supabase/migrations/20260622000000_agent_free_posting.sql.
+// The Supabase client is typed against the pre-migration schema until
+// `npm run db:types` runs, so the new columns/RPC use a targeted cast.
+
+import { supabase } from '../config/supabase';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sb = supabase as unknown as SupabaseClient<any, 'public', any>;
+
+/** Lifetime listing count at or above which a user is auto-treated as an agent. */
+export const AGENT_LIFETIME_LISTING_THRESHOLD = 3;
+
+export const agentFreePostingService = {
+  /** Read the "charge agents" master switch. False (default) = agents post free. */
+  async getChargeAgents(): Promise<boolean> {
+    const { data, error } = await sb
+      .from('admin_settings')
+      .select('charge_agents')
+      .limit(1)
+      .maybeSingle();
+    if (error) throw error;
+    return (data as { charge_agents?: boolean } | null)?.charge_agents === true;
+  },
+
+  /** Admin-only (enforced by admin_settings RLS). Flip the "charge agents" switch. */
+  async setChargeAgents(value: boolean): Promise<void> {
+    const { data: row, error: selErr } = await sb
+      .from('admin_settings')
+      .select('id')
+      .limit(1)
+      .maybeSingle();
+    if (selErr) throw selErr;
+    if (!row?.id) throw new Error('Admin settings not found');
+
+    const { error } = await sb
+      .from('admin_settings')
+      .update({ charge_agents: value })
+      .eq('id', row.id);
+    if (error) throw error;
+  },
+
+  /**
+   * Whether the given user qualifies as a free-posting agent UNDER CURRENT
+   * SETTINGS. Returns false unconditionally when charge_agents is on.
+   *
+   * Caller may pass a known charge_agents value to avoid a redundant read
+   * (the gate already fetches it).
+   */
+  async isUserFreeAgent(
+    userId: string,
+    opts?: { chargeAgents?: boolean },
+  ): Promise<boolean> {
+    const chargeAgents =
+      opts?.chargeAgents ?? (await this.getChargeAgents());
+    if (chargeAgents) return false;
+
+    const [{ data: profile, error: profErr }, { data: count, error: cntErr }] =
+      await Promise.all([
+        sb
+          .from('profiles')
+          .select('role, free_posting_agent')
+          .eq('id', userId)
+          .maybeSingle(),
+        sb.rpc('get_user_lifetime_listing_count', { p_user_id: userId }),
+      ]);
+
+    if (profErr) throw profErr;
+    if (cntErr) throw cntErr;
+
+    const role = (profile as { role?: string } | null)?.role;
+    const flagged =
+      (profile as { free_posting_agent?: boolean } | null)?.free_posting_agent === true;
+    const lifetimeCount = typeof count === 'number' ? count : 0;
+
+    return (
+      role === 'agent' ||
+      flagged ||
+      lifetimeCount >= AGENT_LIFETIME_LISTING_THRESHOLD
+    );
+  },
+};

--- a/supabase/migrations/20260622000000_agent_free_posting.sql
+++ b/supabase/migrations/20260622000000_agent_free_posting.sql
@@ -1,0 +1,85 @@
+/*
+  # Agent-free posting
+
+  Lets agents post residential rentals for free (legacy behavior, normal
+  admin-controlled expiration) while landlords keep paying, WITHOUT deleting
+  any of the paid Agent/VIP subscription machinery.
+
+  Two new switches + one helper:
+
+    1. admin_settings.charge_agents (default false)
+       The "flip a switch later" master control. While false, anyone who
+       qualifies as an agent posts free (payment_kind stays NULL, exactly like
+       the pre-monetization path). Flip to true and agents fall back into the
+       existing subscription / trial / pay-at-posting flow — all that code is
+       left intact, just unreachable for agents until this is on.
+
+    2. profiles.free_posting_agent (default false)
+       Per-user manual override an admin can set from the user-management
+       screen to mark someone as a free-posting agent regardless of role or
+       volume.
+
+    3. get_user_lifetime_listing_count(uuid)
+       Lifetime listing count for a user across BOTH listing tables
+       (listings = rentals + sales, commercial_listings), any status. Used by
+       the posting gate's volume rule (>= 3 lifetime listings => treat as
+       agent). SECURITY DEFINER so the count is reliable regardless of RLS.
+
+  This migration is purely additive. It does NOT touch the monetization master
+  switch, the enable/disable RPCs, or any existing payment logic. If
+  charge_agents is left false but the monetization master switch is also off,
+  behavior is unchanged (everyone posts legacy).
+*/
+
+-- ---------------------------------------------------------------
+-- 1. admin_settings.charge_agents — the future "charge agents" switch.
+-- ---------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'admin_settings' AND column_name = 'charge_agents'
+  ) THEN
+    ALTER TABLE admin_settings ADD COLUMN charge_agents boolean NOT NULL DEFAULT false;
+  END IF;
+END $$;
+
+COMMENT ON COLUMN admin_settings.charge_agents IS
+  'When false (default), users who qualify as agents (role=agent OR free_posting_agent OR >=3 lifetime listings) post residential rentals for free with normal expiration. When true, agents fall back into the existing paid subscription/trial/pay flow. Landlords are unaffected by this switch.';
+
+-- ---------------------------------------------------------------
+-- 2. profiles.free_posting_agent — per-user admin override.
+-- ---------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'profiles' AND column_name = 'free_posting_agent'
+  ) THEN
+    ALTER TABLE profiles ADD COLUMN free_posting_agent boolean NOT NULL DEFAULT false;
+  END IF;
+END $$;
+
+COMMENT ON COLUMN profiles.free_posting_agent IS
+  'Admin-set flag marking a user as a free-posting agent. When true (and admin_settings.charge_agents is false), the user posts residential rentals for free regardless of role or listing volume.';
+
+-- ---------------------------------------------------------------
+-- 3. get_user_lifetime_listing_count — sum across both listing tables.
+-- ---------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_user_lifetime_listing_count(p_user_id uuid)
+RETURNS integer
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  SELECT (
+    (SELECT COUNT(*) FROM listings WHERE user_id = p_user_id)
+    +
+    (SELECT COUNT(*) FROM commercial_listings WHERE user_id = p_user_id)
+  )::integer;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_user_lifetime_listing_count(uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.get_user_lifetime_listing_count(uuid) IS
+  'Lifetime count of all listings a user has ever created across listings (rentals + sales) and commercial_listings, any status. Used by the posting gate''s agent volume rule.';

--- a/supabase/migrations/20260623000000_backfill_agent_listings_legacy_free.sql
+++ b/supabase/migrations/20260623000000_backfill_agent_listings_legacy_free.sql
@@ -1,0 +1,37 @@
+/*
+  # One-time backfill: free existing agents' trial listings
+
+  Companion to 20260622000000_agent_free_posting.sql. That migration makes NEW
+  agent posts free (legacy_free), but existing agent-owned rentals were put on
+  the monetization clock (payment_kind='individual_trial') by the original
+  enable_monetization() grandfather step. While charge_agents is OFF those
+  listings should NOT be charged, get "pay $25" SMS, or be deactivated by the
+  monetization trial-expiry branch.
+
+  This re-tags agent-owned rental listings from 'individual_trial' to
+  'legacy_free' (which every monetization job already excludes). Both active and
+  inactive trials are converted so the reactivation/pay SMS branch also skips
+  them.
+
+  Scope / deliberate exclusions:
+    - 'individual_paid' is LEFT ALONE — those agents bought days; honor them.
+    - 'subscription' is LEFT ALONE — paying subscribers keep their plan.
+    - Only listing_type='rental' (monetization is residential-rental only).
+
+  "Agent" matches the same rule as the posting gate:
+    role='agent' OR free_posting_agent OR lifetime listing count >= 3.
+
+  Idempotent: re-running finds no remaining matching trials.
+*/
+
+UPDATE listings l
+SET payment_kind = 'legacy_free',
+    updated_at = NOW()
+WHERE l.listing_type = 'rental'
+  AND l.payment_kind = 'individual_trial'
+  AND l.user_id IN (
+    SELECT p.id FROM profiles p
+    WHERE p.role = 'agent'
+       OR COALESCE(p.free_posting_agent, false)
+       OR get_user_lifetime_listing_count(p.id) >= 3
+  );


### PR DESCRIPTION
## Summary
Lets agents post residential rentals for free (legacy behavior, normal admin-controlled expiration) while landlords keep paying. All paid Agent/VIP subscription code stays intact and dormant behind a new `charge_agents` switch.

**Who posts free** (while `admin_settings.charge_agents` is OFF — default): a user where ANY of:
- `profiles.role = 'agent'`, OR
- `profiles.free_posting_agent = true` (admin manual toggle), OR
- lifetime listing count (across `listings` + `commercial_listings`) ≥ 3

Free agents post with `payment_kind = 'legacy_free'` and normal `rental_active_days` expiration. Flip `charge_agents` ON later and agents fall back into the existing subscription/trial/$25 flow. Landlords are unaffected either way. Scope: residential rentals only.

## Changes
- New gate mode `agent_free` in `useMonetizationGate.ts` (checked after admin, before the paywall; no race with the phone check)
- New `agentFreePosting` service (charge_agents read/write + eligibility)
- Wizard maps `agent_free → payment_kind 'legacy_free'`; calm "Free to post" panel
- Admin "Charge agents" switch (AdminSubscriptions) + per-user "Free Posting" toggle (AdminPanel)
- Migration `20260622000000` (charge_agents col, free_posting_agent col, get_user_lifetime_listing_count fn) — **already applied to prod**
- One-time backfill `20260623000000`: re-tagged 60 existing agent trial listings → legacy_free — **already applied to prod**

## Verification
- Build + lint green
- Two independent audits passed: implementation logic correct; no monetization SMS/deactivation touches agent (legacy_free) listings while charge_agents is off
- Eligibility verified against live prod data (65/230 users classify as free agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)